### PR TITLE
BNH-14

### DIFF
--- a/web/BricksAndHearts.csproj
+++ b/web/BricksAndHearts.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="6.0.7" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.7">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/web/Program.cs
+++ b/web/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddAuthentication(options => options.DefaultScheme = CookieAuth
 builder.Services.AddTransient<IClaimsTransformation, ClaimsTransformer>();
 builder.Services.AddScoped<ILandlordService, LandlordService>();
 builder.Services.AddScoped<IAdminService, AdminService>();
+builder.Services.AddApplicationInsightsTelemetry();
 
 builder.Services.AddControllersWithViews(options => { options.Filters.Add(new AutoValidateAntiforgeryTokenAttribute()); });
 

--- a/web/appsettings.json
+++ b/web/appsettings.json
@@ -1,6 +1,6 @@
 {  
   "ApplicationInsights": {
-  "ConnectionString" : ""
+    "ConnectionString" : ""
   },
   "Logging": {
     "LogLevel": {

--- a/web/appsettings.json
+++ b/web/appsettings.json
@@ -1,4 +1,7 @@
-{
+{  
+  "ApplicationInsights": {
+  "ConnectionString" : ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
I've updated the appsettingsdevelopment on Keeper with the changes. 
I have a copy saved locally of the original if there's any issues.

We've added telemetry to the application, and it is viewable in the newly created "bricks-and-hearts-telemetry" in Azure Application Insights. We've checked that our requests on our local environment show up in Azure on its live data.
