### PR TITLE
BNH-19

### DIFF
--- a/web/Database/LandlordDbModel.cs
+++ b/web/Database/LandlordDbModel.cs
@@ -15,6 +15,7 @@ public class LandlordDbModel
 
     public string LandlordStatus { get; set; } = null!;
     public bool LandlordProvidedCharterStatus { get; set; } = false;
+    public bool CharterApproved { get; set; } = false;
 
     public virtual UserDbModel? User { get; set; }
     public virtual List<PropertyDbModel>? Properties { get; set; }

--- a/web/Database/LandlordDbModel.cs
+++ b/web/Database/LandlordDbModel.cs
@@ -13,8 +13,11 @@ public class LandlordDbModel
     public string Email { get; set; } = null!;
     public string Phone { get; set; } = null!;
 
-    public string LandlordStatus { get; set; } = null!;
+    //Type of landlord
+    public string LandlordStatus { get; set; } = null!; 
+    //Whether the landlord claims to have signed the charter
     public bool LandlordProvidedCharterStatus { get; set; } = false;
+    //Whether the charter has been approved by an admin
     public bool CharterApproved { get; set; } = false;
 
     public virtual UserDbModel? User { get; set; }

--- a/web/Migrations/20220721095809_AddCharterApproved.Designer.cs
+++ b/web/Migrations/20220721095809_AddCharterApproved.Designer.cs
@@ -4,6 +4,7 @@ using BricksAndHearts.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BricksAndHearts.Migrations
 {
     [DbContext(typeof(BricksAndHeartsDbContext))]
-    partial class BricksAndHeartsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220721095809_AddCharterApproved")]
+    partial class AddCharterApproved
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/web/Migrations/20220721095809_AddCharterApproved.cs
+++ b/web/Migrations/20220721095809_AddCharterApproved.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BricksAndHearts.Migrations
+{
+    public partial class AddCharterApproved : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "CharterApproved",
+                table: "Landlord",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CharterApproved",
+                table: "Landlord");
+        }
+    }
+}

--- a/web/ViewModels/LandlordProfileModel.cs
+++ b/web/ViewModels/LandlordProfileModel.cs
@@ -36,6 +36,8 @@ public class LandlordProfileModel
 
     public bool LandlordProvidedCharterStatus { get; set; } = false;
 
+    public bool CharterApproved { get; set; } = false;
+
     public static LandlordProfileModel FromDbModel(LandlordDbModel landlord)
     {
         return new LandlordProfileModel
@@ -47,7 +49,8 @@ public class LandlordProfileModel
             Phone = landlord.Phone,
             Title = landlord.Title,
             LandlordStatus = landlord.LandlordStatus,
-            LandlordProvidedCharterStatus = landlord.LandlordProvidedCharterStatus
+            LandlordProvidedCharterStatus = landlord.LandlordProvidedCharterStatus,
+            CharterApproved = landlord.CharterApproved
         };
     }
     

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -63,6 +63,13 @@
     </div>
     
     <h4>ChangeAhead Charter</h4>
-    @*TODO: Database does not include this in this branch yet.*@
+    @if (Model.CharterApproved)
+    {
+        <p>Charter status: Approved</p>
+    }
+    else
+    {
+        <p>Charter status: Pending</p>
+    }
     
 </div>


### PR DESCRIPTION
Displays the Landlord Charter Status on a landlord's profile page.
LandlordProvidedCharterStatus already existed as a field in the Landlord table - initialised as false - so I used this. It should perhaps be renamed to better reflect what it represents ('CharterStatus' or 'CharterApproved'?), but I was unsure if this change was worth creating new database migrations so have currently left the name unchanged.