### PR TITLE
BNH-37

### DIFF
--- a/web/Controllers/HomeController.cs
+++ b/web/Controllers/HomeController.cs
@@ -52,4 +52,12 @@ public class HomeController : AbstractController
             StatusMessage = errorInfo.StatusMessage
         });
     }
+
+    [HttpGet]
+    [Route("/ExceptionTest")]
+    public IActionResult ExceptionTest()
+    {
+        throw new Exception("For testing purposes only");
+    }
+    
 }


### PR DESCRIPTION
Adding endpoint which throws exception for testing purposes.

Added the endpoint /ExceptionTest which throws an exception with the message "For Testing Purposes Only"