### PR TITLE
BNH-43 fixed js bug on site launch

### DIFF
--- a/web/wwwroot/js/site.js
+++ b/web/wwwroot/js/site.js
@@ -1,5 +1,7 @@
 ﻿let currentTab = 0;
-showTab(currentTab);
+if (window.location.pathname == "/landlord/register"){
+    showTab(currentTab);
+}
 
 function showTab(currentTab) {
     let tabList = document.getElementsByClassName("registerTab");


### PR DESCRIPTION
set the javascript function for the registration page call to happen onload for registration page rather than when the site is launched, done with onload in a new html body tag around all the main contents of the page