### PR TITLE
BNH-21 - approve landlords

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -1,6 +1,4 @@
-﻿using BricksAndHearts.Controllers;
-using BricksAndHearts.Services;
-using BricksAndHearts.ViewModels;
+﻿using BricksAndHearts.ViewModels;
 using FakeItEasy;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -11,9 +9,6 @@ namespace BricksAndHearts.UnitTests.ControllerTests.Admin;
 
 public class AdminControllerTests : AdminControllerTestsBase
 {
-    private static readonly IAdminService adminService = A.Fake<IAdminService>();
-    private readonly AdminController _underTest = new(null!, adminService);
-    
     [Fact]
     public void Index_WhenCalledByAnonymousUser_ReturnsViewWithLoginLink()
     {

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -1,4 +1,6 @@
-﻿using BricksAndHearts.ViewModels;
+﻿using BricksAndHearts.Controllers;
+using BricksAndHearts.Services;
+using BricksAndHearts.ViewModels;
 using FakeItEasy;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
@@ -9,6 +11,9 @@ namespace BricksAndHearts.UnitTests.ControllerTests.Admin;
 
 public class AdminControllerTests : AdminControllerTestsBase
 {
+    private static readonly IAdminService adminService = A.Fake<IAdminService>();
+    private readonly AdminController _underTest = new(null!, adminService);
+    
     [Fact]
     public void Index_WhenCalledByAnonymousUser_ReturnsViewWithLoginLink()
     {

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
@@ -1,6 +1,17 @@
-﻿namespace BricksAndHearts.UnitTests.ControllerTests.Admin;
+﻿using BricksAndHearts.Controllers;
+using BricksAndHearts.Services;
+using FakeItEasy;
+
+namespace BricksAndHearts.UnitTests.ControllerTests.Admin;
 
 public class AdminControllerTestsBase: ControllerTestsBase
 {
+    protected readonly IAdminService adminService;
+    protected readonly AdminController _underTest;
 
+    protected AdminControllerTestsBase()
+    {
+        adminService = A.Fake<IAdminService>();
+        _underTest = new(null!, adminService);
+    }
 }

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
@@ -1,11 +1,6 @@
-﻿using BricksAndHearts.Controllers;
-using BricksAndHearts.Services;
-using FakeItEasy;
-
-namespace BricksAndHearts.UnitTests.ControllerTests.Admin;
+﻿namespace BricksAndHearts.UnitTests.ControllerTests.Admin;
 
 public class AdminControllerTestsBase: ControllerTestsBase
 {
-    public static readonly IAdminService adminService = A.Fake<IAdminService>();
-    protected readonly AdminController _underTest = new(null!, null!, adminService);
+
 }

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
@@ -1,6 +1,4 @@
-﻿using BricksAndHearts.Controllers;
-using BricksAndHearts.Services;
-using BricksAndHearts.ViewModels;
+﻿using BricksAndHearts.ViewModels;
 using FakeItEasy;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
@@ -10,10 +8,6 @@ namespace BricksAndHearts.UnitTests.ControllerTests.Landlord;
 
 public class LandlordControllerTests : LandlordControllerTestsBase
 {
-    private static readonly IPropertyService propertyService = A.Fake<IPropertyService>();
-    private static readonly ILandlordService landlordService = A.Fake<ILandlordService>();
-    private readonly LandlordController _underTest = new(null!, null!, landlordService, propertyService);
-
     [Fact]
     public void RegisterGet_CalledByUnregisteredUser_ReturnsRegisterViewWithEmail()
     {

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
@@ -1,4 +1,7 @@
-﻿using BricksAndHearts.ViewModels;
+﻿using BricksAndHearts.Controllers;
+using BricksAndHearts.Services;
+using BricksAndHearts.ViewModels;
+using FakeItEasy;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
@@ -7,6 +10,10 @@ namespace BricksAndHearts.UnitTests.ControllerTests.Landlord;
 
 public class LandlordControllerTests : LandlordControllerTestsBase
 {
+    private static readonly IPropertyService propertyService = A.Fake<IPropertyService>();
+    private static readonly ILandlordService landlordService = A.Fake<ILandlordService>();
+    private readonly LandlordController _underTest = new(null!, null!, landlordService, propertyService);
+
     [Fact]
     public void RegisterGet_CalledByUnregisteredUser_ReturnsRegisterViewWithEmail()
     {
@@ -20,5 +27,20 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         // Assert
         result!.Model.Should().BeOfType<LandlordProfileModel>()
             .Which.Email.Should().Be(unregisteredUser.GoogleEmail);
+    }
+
+    [Fact]
+    public async void ApproveCharter_CallsApproveLandlord()
+    {
+        // Arrange 
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, _underTest);
+        var landlord = CreateLandlordUser();
+
+        // Act
+        var result = await _underTest.ApproveCharter(landlord.Id) as ViewResult;
+
+        // Assert
+        A.CallTo(() => landlordService.ApproveLandlord(landlord.Id, adminUser)).MustHaveHappened();
     }
 }

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
@@ -1,4 +1,4 @@
-﻿using BricksAndHearts.Controllers;
+using BricksAndHearts.Controllers;
 using BricksAndHearts.Services;
 using FakeItEasy;
 

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
@@ -6,6 +6,14 @@ namespace BricksAndHearts.UnitTests.ControllerTests.Landlord;
 
 public class LandlordControllerTestsBase : ControllerTestsBase
 {
-    public static readonly IPropertyService propertyService = A.Fake<IPropertyService>();
-    protected readonly LandlordController _underTest = new(null!, null!, new LandlordService(null!), propertyService,null!);
+    protected readonly IPropertyService propertyService;
+    protected readonly ILandlordService landlordService;
+    protected readonly LandlordController _underTest;
+
+    protected LandlordControllerTestsBase()
+    {
+        landlordService = A.Fake<ILandlordService>();
+        propertyService = A.Fake<IPropertyService>();
+        _underTest = new(null!, landlordService, propertyService, null!);
+    }
 }

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -22,7 +22,6 @@ public class AdminController : AbstractController
     {
         _logger = logger;
         _adminService = adminService;
-        _dbContext = dbContext;
     }
 
     public IActionResult Index()

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -14,11 +14,9 @@ namespace BricksAndHearts.Controllers;
 public class AdminController : AbstractController
 {
     private readonly IAdminService _adminService;
-    private readonly BricksAndHeartsDbContext _dbContext;
     private readonly ILogger<AdminController> _logger;
 
-    public AdminController(ILogger<AdminController> logger, BricksAndHeartsDbContext dbContext,
-        IAdminService adminService)
+    public AdminController(ILogger<AdminController> logger, IAdminService adminService)
     {
         _logger = logger;
         _adminService = adminService;

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -15,8 +15,7 @@ public class LandlordController : AbstractController
     private readonly IMailService _mailService;
     private readonly ILogger<LandlordController> _logger;
 
-    public LandlordController(ILogger<LandlordController> logger, BricksAndHeartsDbContext dbContext,
-        ILandlordService landlordService, IPropertyService propertyService, IMailService mailService)
+    public LandlordController(ILogger<LandlordController> logger, ILandlordService landlordService, IPropertyService propertyService, IMailService mailService)
     {
         _logger = logger;
         _landlordService = landlordService;

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -118,6 +118,15 @@ public class LandlordController : AbstractController
 
         return await Profile(landlordId.Value);
     }
+    
+    [Authorize(Roles="Admin")]
+    [HttpPost]
+    public async Task<ActionResult> ApproveCharter(int landlordId)
+    {
+        var user = GetCurrentUser();
+        await _landlordService.ApproveLandlord(landlordId, user);
+        return RedirectToAction("Profile", "Landlord", new { Id = landlordId });
+    }
 
     [HttpGet]
     [Route("/properties")]

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -102,7 +102,7 @@ public class LandlordController : AbstractController
             return StatusCode(404);
         }
 
-        var viewModel = LandlordProfileModel.FromDbModel(landlord);
+        var viewModel = LandlordProfileModel.FromDbModel(landlord, user);
         return View("Profile", viewModel);
     }
 

--- a/web/Database/LandlordDbModel.cs
+++ b/web/Database/LandlordDbModel.cs
@@ -19,6 +19,8 @@ public class LandlordDbModel
     public bool LandlordProvidedCharterStatus { get; set; } = false;
     //Whether the charter has been approved by an admin
     public bool CharterApproved { get; set; } = false;
+    public DateTime? ApprovalTime { get; set; }
+    public int? ApprovalAdminId { get; set; }
 
     public virtual UserDbModel? User { get; set; }
     public virtual List<PropertyDbModel> Properties { get; set; } = new();

--- a/web/Migrations/20220722110224_AddCharterApprovalDetails.Designer.cs
+++ b/web/Migrations/20220722110224_AddCharterApprovalDetails.Designer.cs
@@ -4,6 +4,7 @@ using BricksAndHearts.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BricksAndHearts.Migrations
 {
     [DbContext(typeof(BricksAndHeartsDbContext))]
-    partial class BricksAndHeartsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220722110224_AddCharterApprovalDetails")]
+    partial class AddCharterApprovalDetails
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -82,46 +84,12 @@ namespace BricksAndHearts.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
-                    b.Property<string>("AddressLine1")
+                    b.Property<string>("Address")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("AddressLine2")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("AddressLine3")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("County")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<DateTime?>("CreationTime")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<bool>("IsIncomplete")
-                        .HasColumnType("bit");
 
                     b.Property<int>("LandlordId")
                         .HasColumnType("int");
-
-                    b.Property<int?>("NumOfBedrooms")
-                        .HasColumnType("int");
-
-                    b.Property<string>("Postcode")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("PropertyType")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<int?>("Rent")
-                        .HasColumnType("int");
-
-                    b.Property<string>("TownOrCity")
-                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");
 

--- a/web/Migrations/20220722110224_AddCharterApprovalDetails.cs
+++ b/web/Migrations/20220722110224_AddCharterApprovalDetails.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BricksAndHearts.Migrations
+{
+    public partial class AddCharterApprovalDetails : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ApprovalAdminId",
+                table: "Landlord",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ApprovalTime",
+                table: "Landlord",
+                type: "datetime2",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ApprovalAdminId",
+                table: "Landlord");
+
+            migrationBuilder.DropColumn(
+                name: "ApprovalTime",
+                table: "Landlord");
+        }
+    }
+}

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -18,7 +18,6 @@ public interface ILandlordService
     public Task<LandlordRegistrationResult> RegisterLandlordWithUser(LandlordProfileModel createModel, BricksAndHeartsUser user);
     public Task<LandlordDbModel?> GetLandlordIfExistsFromId(int id);
     public Task ApproveLandlord(int landlordId, BricksAndHeartsUser user);
-    public List<PropertyDbModel> GetListOfProperties(int landlordId);
 }
 
 public class LandlordService : ILandlordService
@@ -88,15 +87,16 @@ public class LandlordService : ILandlordService
     public async Task ApproveLandlord(int landlordId,  BricksAndHeartsUser user)
     {
         var landlord = _dbContext.Landlords.Single(l =>l.Id == landlordId);
-        landlord.CharterApproved = true;
-        landlord.ApprovalTime = DateTime.Now;
-        landlord.ApprovalAdminId = user.Id;
-        await _dbContext.SaveChangesAsync();
-    }
-    
-    public List<PropertyDbModel> GetListOfProperties(int landlordId)
-    {
-        return _dbContext.Properties
-            .Where(p => p.LandlordId == landlordId).ToList();
+        if (!landlord.CharterApproved)
+        {
+            landlord.CharterApproved = true;
+            landlord.ApprovalTime = DateTime.Now;
+            landlord.ApprovalAdminId = user.Id;
+            await _dbContext.SaveChangesAsync();
+        }
+        else
+        {
+            throw new Exception("Landlord already approved");
+        }
     }
 }

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -16,9 +16,9 @@ public interface ILandlordService
     }
 
     public Task<LandlordRegistrationResult> RegisterLandlordWithUser(LandlordProfileModel createModel, BricksAndHeartsUser user);
-    public List<PropertyDbModel> GetListOfProperties(int landlordId);
     public Task<LandlordDbModel?> GetLandlordIfExistsFromId(int id);
-
+    public Task ApproveLandlord(int landlordId, BricksAndHeartsUser user);
+    public List<PropertyDbModel> GetListOfProperties(int landlordId);
 }
 
 public class LandlordService : ILandlordService
@@ -85,6 +85,15 @@ public class LandlordService : ILandlordService
         return _dbContext.Landlords.SingleOrDefaultAsync(l => l.Id == id);
     }
 
+    public async Task ApproveLandlord(int landlordId,  BricksAndHeartsUser user)
+    {
+        var landlord = _dbContext.Landlords.Single(l =>l.Id == landlordId);
+        landlord.CharterApproved = true;
+        landlord.ApprovalTime = DateTime.Now;
+        landlord.ApprovalAdminId = user.Id;
+        await _dbContext.SaveChangesAsync();
+    }
+    
     public List<PropertyDbModel> GetListOfProperties(int landlordId)
     {
         return _dbContext.Properties

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -81,22 +81,24 @@ public class LandlordService : ILandlordService
 
     public Task<LandlordDbModel?> GetLandlordIfExistsFromId(int id)
     {
-        return _dbContext.Landlords.SingleOrDefaultAsync(l => l.Id == id);
+        var landlord = _dbContext.Landlords.SingleOrDefaultAsync(l => l.Id == id);
+        if (landlord is null)
+        {
+            throw new Exception("Landlord does not exist");
+        }
+        return landlord;
     }
 
     public async Task ApproveLandlord(int landlordId,  BricksAndHeartsUser user)
     {
-        var landlord = _dbContext.Landlords.Single(l =>l.Id == landlordId);
-        if (!landlord.CharterApproved)
-        {
-            landlord.CharterApproved = true;
-            landlord.ApprovalTime = DateTime.Now;
-            landlord.ApprovalAdminId = user.Id;
-            await _dbContext.SaveChangesAsync();
-        }
-        else
+        var landlord = await GetLandlordIfExistsFromId(landlordId);
+        if (landlord!.CharterApproved)
         {
             throw new Exception("Landlord already approved");
         }
+        landlord.CharterApproved = true;
+        landlord.ApprovalTime = DateTime.Now;
+        landlord.ApprovalAdminId = user.Id;
+        await _dbContext.SaveChangesAsync();
     }
 }

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -81,17 +81,16 @@ public class LandlordService : ILandlordService
 
     public Task<LandlordDbModel?> GetLandlordIfExistsFromId(int id)
     {
-        var landlord = _dbContext.Landlords.SingleOrDefaultAsync(l => l.Id == id);
-        if (landlord is null)
-        {
-            throw new Exception("Landlord does not exist");
-        }
-        return landlord;
+        return _dbContext.Landlords.SingleOrDefaultAsync(l => l.Id == id);
     }
 
     public async Task ApproveLandlord(int landlordId,  BricksAndHeartsUser user)
     {
         var landlord = await GetLandlordIfExistsFromId(landlordId);
+        if (landlord is null)
+        {
+            throw new Exception("Landlord does not exist");
+        }
         if (landlord!.CharterApproved)
         {
             throw new Exception("Landlord already approved");

--- a/web/ViewModels/LandlordProfileModel.cs
+++ b/web/ViewModels/LandlordProfileModel.cs
@@ -1,11 +1,14 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using BricksAndHearts.Auth;
 using BricksAndHearts.Database;
 
 namespace BricksAndHearts.ViewModels;
 
 public class LandlordProfileModel
 {
+    public int Id { get; set; }
+
     [Required]
     [StringLength(60)]
     [DisplayName("Title")]
@@ -38,10 +41,14 @@ public class LandlordProfileModel
 
     public bool CharterApproved { get; set; } = false;
 
-    public static LandlordProfileModel FromDbModel(LandlordDbModel landlord)
+    public bool CurrentUserIsAdmin { get; set; }
+    public int CurrentUserId { get; set; }
+
+    public static LandlordProfileModel FromDbModel(LandlordDbModel landlord, BricksAndHeartsUser user)
     {
         return new LandlordProfileModel
         {
+            Id = landlord.Id,
             CompanyName = landlord.CompanyName,
             Email = landlord.Email,
             FirstName = landlord.FirstName,
@@ -50,7 +57,9 @@ public class LandlordProfileModel
             Title = landlord.Title,
             LandlordStatus = landlord.LandlordStatus,
             LandlordProvidedCharterStatus = landlord.LandlordProvidedCharterStatus,
-            CharterApproved = landlord.CharterApproved
+            CharterApproved = landlord.CharterApproved,
+            CurrentUserIsAdmin = user.IsAdmin,
+            CurrentUserId = user.Id
         };
     }
     

--- a/web/ViewModels/LandlordProfileModel.cs
+++ b/web/ViewModels/LandlordProfileModel.cs
@@ -7,7 +7,7 @@ namespace BricksAndHearts.ViewModels;
 
 public class LandlordProfileModel
 {
-    public int Id { get; set; }
+    public int LandlordId { get; set; }
 
     [Required]
     [StringLength(60)]
@@ -42,13 +42,12 @@ public class LandlordProfileModel
     public bool CharterApproved { get; set; } = false;
 
     public bool CurrentUserIsAdmin { get; set; }
-    public int CurrentUserId { get; set; }
 
     public static LandlordProfileModel FromDbModel(LandlordDbModel landlord, BricksAndHeartsUser user)
     {
         return new LandlordProfileModel
         {
-            Id = landlord.Id,
+            LandlordId = landlord.Id,
             CompanyName = landlord.CompanyName,
             Email = landlord.Email,
             FirstName = landlord.FirstName,
@@ -58,8 +57,7 @@ public class LandlordProfileModel
             LandlordStatus = landlord.LandlordStatus,
             LandlordProvidedCharterStatus = landlord.LandlordProvidedCharterStatus,
             CharterApproved = landlord.CharterApproved,
-            CurrentUserIsAdmin = user.IsAdmin,
-            CurrentUserId = user.Id
+            CurrentUserIsAdmin = user.IsAdmin
         };
     }
     

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -74,7 +74,7 @@
         {
             @using (Html.BeginForm("ApproveCharter", "Landlord", FormMethod.Post))
             {
-                <input type="hidden" id="landlordId" name="landlordId" value=@Model.Id>
+                <input type="hidden" id="landlordId" name="landlordId" value=@Model.LandlordId>
                 <button type="submit" class="btn-primary">Approve Landlord</button>
             }
         }

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -72,4 +72,13 @@
         <p>Charter status: Pending</p>
     }
     
+    @if (Model.CurrentUserIsAdmin)
+    {
+        @using (Html.BeginForm("ApproveCharter", "Admin", FormMethod.Post))
+        {
+            <input type="hidden" id="checkInId" name="Id" value=@Model.Id>
+            <button type="submit" class="btn custom-btn-primary">Approve Landlord</button>
+        }
+    }
+
 </div>

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -75,9 +75,8 @@
             @using (Html.BeginForm("ApproveCharter", "Landlord", FormMethod.Post))
             {
                 <input type="hidden" id="landlordId" name="landlordId" value=@Model.Id>
-                <button type="submit" class="btn custom-btn-primary">Approve Landlord</button>
+                <button type="submit" class="btn-primary">Approve Landlord</button>
             }
         }
     }
-
 </div>

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -70,14 +70,13 @@
     else
     {
         <p>Charter status: Pending</p>
-    }
-    
-    @if (Model.CurrentUserIsAdmin)
-    {
-        @using (Html.BeginForm("ApproveCharter", "Landlord", FormMethod.Post))
+        @if (Model.CurrentUserIsAdmin)
         {
-            <input type="hidden" id="landlordId" name="landlordId" value=@Model.Id>
-            <button type="submit" class="btn custom-btn-primary">Approve Landlord</button>
+            @using (Html.BeginForm("ApproveCharter", "Landlord", FormMethod.Post))
+            {
+                <input type="hidden" id="landlordId" name="landlordId" value=@Model.Id>
+                <button type="submit" class="btn custom-btn-primary">Approve Landlord</button>
+            }
         }
     }
 

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -74,9 +74,9 @@
     
     @if (Model.CurrentUserIsAdmin)
     {
-        @using (Html.BeginForm("ApproveCharter", "Admin", FormMethod.Post))
+        @using (Html.BeginForm("ApproveCharter", "Landlord", FormMethod.Post))
         {
-            <input type="hidden" id="checkInId" name="Id" value=@Model.Id>
+            <input type="hidden" id="landlordId" name="landlordId" value=@Model.Id>
             <button type="submit" class="btn custom-btn-primary">Approve Landlord</button>
         }
     }


### PR DESCRIPTION
When an admin views the profile page of an unapproved landlord, beneath the 'Charter Status' heading there will be a button to 'Approve Landlord'. This does not appear when the current user is not an admin or when the landlord is already approved.
When clicked, this button changes some entries in the appropriate row of the Landlord table in the database: CharterApproved becomes 'true', ApprovalTime sets to the current DateTime and ApprovalAdminId set to the Id of the current user.
[THERE ARE DATABASE MIGRATIONS IN THIS PULL REQUEST]

Profile page view with button (only change is under 'Charter Status' heading
![image](https://user-images.githubusercontent.com/108676120/180432058-dc450ef1-d630-48de-b51b-363ead8d7c5d.png)
