### PR TITLE
Bnh 44

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -37,7 +37,7 @@ public class AdminControllerTests : AdminControllerTestsBase
         var result = await UnderTest.LandlordList() as ViewResult;
 
         // Assert
-        A.CallTo(() => AdminService.GetLandlordDisplayList("All")).MustHaveHappened();
+        A.CallTo(() => AdminService.GetLandlordDisplayList("")).MustHaveHappened();
         result!.ViewData.Model.Should().BeOfType<LandlordListModel?>();
     }
 }

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -27,7 +27,7 @@ public class AdminControllerTests : AdminControllerTestsBase
     }
 
     [Fact]
-    public async void LandlordList_WhenCalled_CallsGetUnapprovedLandlordsAndReturnsLandlordListView()
+    public async void LandlordList_WhenCalled_CallsGetLandlordListAndReturnsLandlordListView()
     {
         // Arrange
         var adminUser = CreateAdminUser();
@@ -37,7 +37,7 @@ public class AdminControllerTests : AdminControllerTestsBase
         var result = await UnderTest.LandlordList() as ViewResult;
 
         // Assert
-        A.CallTo(() => AdminService.GetUnapprovedLandlords()).MustHaveHappened();
+        A.CallTo(() => AdminService.GetLandlordDisplayList("All")).MustHaveHappened();
         result!.ViewData.Model.Should().BeOfType<LandlordListModel?>();
     }
 }

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
@@ -12,6 +12,6 @@ public class AdminControllerTestsBase: ControllerTestsBase
     protected AdminControllerTestsBase()
     {
         AdminService = A.Fake<IAdminService>();
-        UnderTest = new AdminController(null!, null!, AdminService);
+        UnderTest = new AdminController(null!, AdminService);
     }
 }

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -1,7 +1,6 @@
 #region
 
 using BricksAndHearts.Auth;
-using BricksAndHearts.Database;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using Microsoft.AspNetCore.Authorization;
@@ -14,14 +13,12 @@ namespace BricksAndHearts.Controllers;
 public class AdminController : AbstractController
 {
     private readonly IAdminService _adminService;
-    private readonly BricksAndHeartsDbContext _dbContext;
     private readonly ILogger<AdminController> _logger;
 
-    public AdminController(ILogger<AdminController> logger, BricksAndHeartsDbContext dbContext, IAdminService adminService)
+    public AdminController(ILogger<AdminController> logger, IAdminService adminService)
     {
         _logger = logger;
         _adminService = adminService;
-        _dbContext = dbContext;
     }
 
     public IActionResult Index()
@@ -82,8 +79,17 @@ public class AdminController : AbstractController
     [HttpGet]
     public async Task<IActionResult> LandlordList()
     {
-        var landlordListModel = new LandlordListModel();
-        landlordListModel.UnapprovedLandlords = await _adminService.GetUnapprovedLandlords();
+        LandlordListModel landlordListModel = new LandlordListModel();
+        landlordListModel.LandlordDisplayList = await _adminService.GetLandlordDisplayList("All");
+        return View(landlordListModel);
+    }
+    
+    [Authorize(Roles="Admin")]
+    [HttpPost]
+    public async Task<IActionResult> LandlordList(string? approvalStatus)
+    {
+        LandlordListModel landlordListModel = new LandlordListModel();
+        landlordListModel.LandlordDisplayList = await _adminService.GetLandlordDisplayList(approvalStatus);
         return View(landlordListModel);
     }
 

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -77,19 +77,10 @@ public class AdminController : AbstractController
 
     [Authorize(Roles = "Admin")]
     [HttpGet]
-    public async Task<IActionResult> LandlordList()
+    public async Task<IActionResult> LandlordList(string? approvalStatus = "")
     {
         LandlordListModel landlordListModel = new LandlordListModel();
-        landlordListModel.LandlordDisplayList = await _adminService.GetLandlordDisplayList("All");
-        return View(landlordListModel);
-    }
-    
-    [Authorize(Roles="Admin")]
-    [HttpPost]
-    public async Task<IActionResult> LandlordList(string? approvalStatus)
-    {
-        LandlordListModel landlordListModel = new LandlordListModel();
-        landlordListModel.LandlordDisplayList = await _adminService.GetLandlordDisplayList(approvalStatus);
+        landlordListModel.LandlordDisplayList = await _adminService.GetLandlordDisplayList(approvalStatus!);
         return View(landlordListModel);
     }
 

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -38,14 +38,11 @@ public class AdminController : AbstractController
         if (user.IsAdmin)
         {
             LoggerAlreadyAdminWarning(_logger, user);
-
             return RedirectToAction(nameof(Index));
         }
 
         _adminService.RequestAdminAccess(user);
-
         FlashRequestSuccess(_logger, user, "requested admin access");
-
         return RedirectToAction(nameof(Index));
     }
 
@@ -55,14 +52,11 @@ public class AdminController : AbstractController
         if (user.IsAdmin)
         {
             LoggerAlreadyAdminWarning(_logger, user);
-
             return RedirectToAction(nameof(Index));
         }
 
         _adminService.CancelAdminAccessRequest(user);
-
         FlashRequestSuccess(_logger, user, "cancelled admin access request");
-
         return RedirectToAction(nameof(Index));
     }
 

--- a/web/Services/AdminService.cs
+++ b/web/Services/AdminService.cs
@@ -48,8 +48,8 @@ public class AdminService : IAdminService
 
     private async Task<List<UserDbModel>> GetPendingAdmins()
     {
-        List<UserDbModel> PendingAdmins = await _dbContext.Users.Where(u => u.IsAdmin == false && u.HasRequestedAdmin).ToListAsync();
-        return PendingAdmins;
+        List<UserDbModel> pendingAdmins = await _dbContext.Users.Where(u => u.IsAdmin == false && u.HasRequestedAdmin).ToListAsync();
+        return pendingAdmins;
     }
 
     public async Task<(List<UserDbModel> CurrentAdmins, List<UserDbModel> PendingAdmins)> GetAdminLists()

--- a/web/ViewModels/LandlordListModel.cs
+++ b/web/ViewModels/LandlordListModel.cs
@@ -3,5 +3,5 @@ namespace BricksAndHearts.ViewModels;
 
 public class LandlordListModel
 {
-    public List<LandlordDbModel>? UnapprovedLandlords { get; set; }
+    public List<LandlordDbModel>? LandlordDisplayList { get; set; }
 }

--- a/web/Views/Admin/LandlordList.cshtml
+++ b/web/Views/Admin/LandlordList.cshtml
@@ -4,7 +4,20 @@
     ViewData["Title"] = "Landlord List";
 }
 
-<h2>Unapproved Landlords</h2>
+<h2>Landlord List</h2>
+
+<div class="mb-3">
+    @using (Html.BeginForm("LandlordList", "Admin", FormMethod.Post))
+    {
+        <select class="form-select" id="approvalStatus" name="approvalStatus">
+            <option disabled selected>Filter by approval status</option>
+            <option value="">Display all landlords</option>
+            <option value="Unapproved">Display unapproved landlords</option>
+            <option value="Approved">Display approved landlords</option>
+        </select>
+        <button type="submit" class="btn custom-btn-primary">Display results</button>
+    }
+</div>
 
 <table class="table table-hover">
     <thead>
@@ -17,7 +30,7 @@
     </tr>
     </thead>
     <tbody>
-    @foreach (var landlord in Model.UnapprovedLandlords!)
+    @foreach (var landlord in Model.LandlordDisplayList!)
     {
         <tr class ="clickable"
             onclick="location.href = '@Url.Action("Profile", "Landlord", new { id = landlord!.Id })'">

--- a/web/Views/Admin/LandlordList.cshtml
+++ b/web/Views/Admin/LandlordList.cshtml
@@ -7,7 +7,7 @@
 <h2>Landlord List</h2>
 
 <div class="mb-3">
-    @using (Html.BeginForm("LandlordList", "Admin", FormMethod.Post))
+    @using (Html.BeginForm("LandlordList", "Admin", FormMethod.Get))
     {
         <select class="form-select" id="approvalStatus" name="approvalStatus">
             <option disabled selected>Filter by approval status</option>


### PR DESCRIPTION
LandlordList page defaults to displaying a list of all landlords. There is then an option to filter the list to display 'Unapproved', 'Approved', or 'All'.
This is written as a Get Request, because using a Post Request caused the 'confirm form resubmission page' to inconveniently appear if, after clicking on a landlord to see their profile, the user uses the browser back button to return to the Landlord List.