### PR TITLE
BNH-61 Unit tests for database methods

### DIFF
--- a/.github/workflows/test_on_push_bricks-and-hearts.yml
+++ b/.github/workflows/test_on_push_bricks-and-hearts.yml
@@ -12,6 +12,21 @@ jobs:
   build:
     name: Build and run tests
     runs-on: ubuntu-latest
+    
+    services:
+      sqlserver:
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: JdMsKZPBBA8kVFXVrj8d
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'JdMsKZPBBA8kVFXVrj8d' -Q 'SELECT 1' || exit 1"
+          --health-interval 10s
+          --health-timeout 3s
+          --health-retries 10
+          --health-start-period 10s
 
     steps:
       - uses: actions/checkout@v2
@@ -24,6 +39,14 @@ jobs:
 
       - name: Build with dotnet
         run: dotnet build -warnaserror
+        
+      # Substitute entries in appsettings.json for CI
+      - name: App Settings variable substitution
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: 'web/appsettings.json'
+        env:
+          TestDBConnectionString: 'Server=localhost,1433;Database=BricksAndHeartsTest;User Id=SA;Password=JdMsKZPBBA8kVFXVrj8d;'
 
       - name: Test with dotnet
         run: dotnet test

--- a/.github/workflows/test_on_push_bricks-and-hearts.yml
+++ b/.github/workflows/test_on_push_bricks-and-hearts.yml
@@ -23,10 +23,10 @@ jobs:
           - 1433:1433
         options: >-
           --health-cmd "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'JdMsKZPBBA8kVFXVrj8d' -Q 'SELECT 1' || exit 1"
-          --health-interval 10s
+          --health-interval 3s
           --health-timeout 3s
-          --health-retries 10
-          --health-start-period 10s
+          --health-retries 20
+          --health-start-period 5s
 
     steps:
       - uses: actions/checkout@v2

--- a/BricksAndHearts.UnitTests/ServiceTests/Admin/AdminServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Admin/AdminServiceTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Linq;
+using BricksAndHearts.Auth;
+using BricksAndHearts.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace BricksAndHearts.UnitTests.ServiceTests.Admin;
+
+public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
+{
+    private TestDatabaseFixture Fixture { get; }
+
+    public AdminServiceTests(TestDatabaseFixture fixture)
+    {
+        Fixture = fixture;
+    }
+
+    [Fact]
+    public async void GetAdminLists_OnlyGetsAdmins()
+    {
+        // Arrange
+        await using var context = Fixture.CreateReadContext();
+        var service = new AdminService(context);
+
+        var adminUser = context.Users.Single(u => u.GoogleUserName == "AdminUser");
+
+        // Act
+        var adminLists = await service.GetAdminLists();
+
+        // Assert
+        adminLists.CurrentAdmins.Should().OnlyContain(u => u.Id == adminUser.Id);
+    }
+
+    [Fact]
+    public void RequestAdminAccess_SetsHasRequestedAdminToTrue_ForCorrectUser()
+    {
+        // Arrange
+        using var context = Fixture.CreateWriteContext();
+        var service = new AdminService(context);
+
+        var nonAdminUser = context.Users.Single(u => u.GoogleUserName == "NonAdminUser");
+        var adminUser = context.Users.Single(u => u.GoogleUserName == "AdminUser");
+
+        // Act
+        service.RequestAdminAccess(new BricksAndHeartsUser(nonAdminUser, null!, null!));
+
+        // Before assert we need to clear the context's change tracker so that the following database queries actually
+        // query the database, as if this were a new context. This should be done for all write tests.
+        context.ChangeTracker.Clear();
+
+        // Assert
+        context.Users.Single(u => u.Id == nonAdminUser.Id).HasRequestedAdmin.Should().BeTrue();
+        context.Users.Single(u => u.Id == adminUser.Id).HasRequestedAdmin.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CancelAdminAccessRequest_SetsHasRequestedAdminToFalse_ForCorrectUser()
+    {
+        // Arrange
+        using var context = Fixture.CreateWriteContext();
+        var service = new AdminService(context);
+
+        var requestedAdminUser = context.Users.Single(u => u.GoogleUserName == "NonAdminUser");
+
+        // Act
+        service.CancelAdminAccessRequest(new BricksAndHeartsUser(requestedAdminUser, null!, null!));
+
+        // Before assert we need to clear the context's change tracker so that the following database queries actually
+        // query the database, as if this were a new context. This should be done for all write tests.
+        context.ChangeTracker.Clear();
+
+        // Assert
+        context.Users.Single(u => u.Id == requestedAdminUser.Id).HasRequestedAdmin.Should().BeFalse();
+    }
+}

--- a/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
@@ -32,7 +32,7 @@ public class TestDatabaseFixture
     private BricksAndHeartsDbContext CreateContext()
     {
         var config = new ConfigurationManager();
-        config.AddJsonFile("appsettings.Development.json");
+        config.AddJsonFile("appsettings.json");
         return new TestDbContext(config);
     }
 

--- a/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
@@ -1,4 +1,5 @@
 ﻿using BricksAndHearts.Database;
+using Microsoft.Extensions.Configuration;
 
 namespace BricksAndHearts.UnitTests.ServiceTests;
 
@@ -12,7 +13,7 @@ public class TestDatabaseFixture
         lock (Lock)
         {
             if (_databaseInitialised) return;
-            using (var context = new TestDbContext())
+            using (var context = CreateContext())
             {
                 context.Database.EnsureDeleted();
                 context.Database.EnsureCreated();
@@ -28,14 +29,21 @@ public class TestDatabaseFixture
         }
     }
 
+    private BricksAndHeartsDbContext CreateContext()
+    {
+        var config = new ConfigurationManager();
+        config.AddJsonFile("appsettings.Development.json");
+        return new TestDbContext(config);
+    }
+
     public BricksAndHeartsDbContext CreateReadContext()
     {
-        return new TestDbContext();
+        return CreateContext();
     }
 
     public BricksAndHeartsDbContext CreateWriteContext()
     {
-        var context = new TestDbContext();
+        var context = CreateContext();
         // Begin a transaction so the test's writes don't interfere with other tests running in parallel (provides test isolation)
         // Transaction is never committed so is automatically rolled back at the end of the test
         context.Database.BeginTransaction();

--- a/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
@@ -1,0 +1,83 @@
+﻿using BricksAndHearts.Database;
+
+namespace BricksAndHearts.UnitTests.ServiceTests;
+
+public class TestDatabaseFixture
+{
+    private static readonly object Lock = new();
+    private static bool _databaseInitialised;
+
+    public TestDatabaseFixture()
+    {
+        lock (Lock)
+        {
+            if (_databaseInitialised) return;
+            using (var context = new TestDbContext())
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+
+                context.Users.AddRange(
+                    CreateAdminUser(),
+                    CreateNonAdminUser(),
+                    CreateRequestedAdminUser());
+                context.SaveChanges();
+            }
+
+            _databaseInitialised = true;
+        }
+    }
+
+    public BricksAndHeartsDbContext CreateReadContext()
+    {
+        return new TestDbContext();
+    }
+
+    public BricksAndHeartsDbContext CreateWriteContext()
+    {
+        var context = new TestDbContext();
+        // Begin a transaction so the test's writes don't interfere with other tests running in parallel (provides test isolation)
+        // Transaction is never committed so is automatically rolled back at the end of the test
+        context.Database.BeginTransaction();
+        return context;
+    }
+
+    public UserDbModel CreateAdminUser()
+    {
+        return new UserDbModel
+        {
+            GoogleUserName = "AdminUser",
+            GoogleEmail = "test.email@gmail.com",
+            GoogleAccountId = "1",
+            IsAdmin = true,
+            LandlordId = null,
+            HasRequestedAdmin = false
+        };
+    }
+
+    public UserDbModel CreateNonAdminUser()
+    {
+        return new UserDbModel
+        {
+            GoogleUserName = "NonAdminUser",
+            GoogleEmail = "test.email2@gmail.com",
+            GoogleAccountId = "2",
+            IsAdmin = false,
+            LandlordId = null,
+            HasRequestedAdmin = false
+        };
+    }
+
+    public UserDbModel CreateRequestedAdminUser()
+    {
+        return new UserDbModel
+        {
+            GoogleUserName = "HasRequestedAdminUser",
+            GoogleEmail = "test.email3@gmail.com",
+            GoogleAccountId = "3",
+            IsAdmin = false,
+            LandlordId = null,
+            HasRequestedAdmin = true
+        };
+    }
+}

--- a/BricksAndHearts.UnitTests/ServiceTests/TestDbContext.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/TestDbContext.cs
@@ -2,7 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 
-namespace BricksAndHearts.UnitTests;
+namespace BricksAndHearts.UnitTests.ServiceTests;
 
 public class TestDbContext : BricksAndHeartsDbContext
 {

--- a/BricksAndHearts.UnitTests/TestDbContext.cs
+++ b/BricksAndHearts.UnitTests/TestDbContext.cs
@@ -1,0 +1,19 @@
+﻿using BricksAndHearts.Database;
+using Microsoft.EntityFrameworkCore;
+
+namespace BricksAndHearts.UnitTests;
+
+public class TestDbContext : BricksAndHeartsDbContext
+{
+    private const string ConnectionString =
+        "Server=(local);Database=BricksAndHeartsTest;Trusted_Connection=True;Integrated Security=True;";
+
+    public TestDbContext() : base(null!)
+    {
+    }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(ConnectionString);
+    }
+}

--- a/BricksAndHearts.UnitTests/TestDbContext.cs
+++ b/BricksAndHearts.UnitTests/TestDbContext.cs
@@ -1,19 +1,20 @@
 ﻿using BricksAndHearts.Database;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 
 namespace BricksAndHearts.UnitTests;
 
 public class TestDbContext : BricksAndHeartsDbContext
 {
-    private const string ConnectionString =
-        "Server=(local);Database=BricksAndHeartsTest;Trusted_Connection=True;Integrated Security=True;";
+    private readonly IConfiguration _config;
 
-    public TestDbContext() : base(null!)
+    public TestDbContext(IConfiguration config) : base(config)
     {
+        _config = config;
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        optionsBuilder.UseSqlServer(ConnectionString);
+        optionsBuilder.UseSqlServer(_config["TestDBConnectionString"]);
     }
 }

--- a/web/appsettings.json
+++ b/web/appsettings.json
@@ -1,6 +1,6 @@
 {  
   "ApplicationInsights": {
-    "ConnectionString" : ""
+    "ConnectionString": ""
   },
   "Logging": {
     "LogLevel": {
@@ -10,11 +10,12 @@
   },
   "AllowedHosts": "*",
   "DBConnectionString": "Server=(local);Database=BricksAndHearts;Trusted_Connection=True;Integrated Security=True;",
+  "TestDBConnectionString": "Server=(local);Database=BricksAndHeartsTest;Trusted_Connection=True;Integrated Security=True;",
   "MigrateOnStartup": true,
-  "Authentication" : {
-    "Google" : {
-      "ClientId" : "",
-      "ClientSecret" : ""
+  "Authentication": {
+    "Google": {
+      "ClientId": "",
+      "ClientSecret": ""
     }
   }
 }


### PR DESCRIPTION
## Summary of changes

- Created a framework for unit testing our database operations found in the Service classes, following [this guide](https://docs.microsoft.com/en-us/ef/core/testing/testing-with-the-database) from the Entity Framework docs
- This uses a new `BricksAndHeartsTest` database
- This can test read and write operations, and uses a non-committing transaction to maintain isolation between tests
- The pull request GitHub Action has been updated to now run an instance of SQL Server, which is used when these tests are run for pull requests
- Added a small number of example tests for `AdminService` to demonstrate how this should be used



### Previous comment
> Following [EF's advice](https://docs.microsoft.com/en-us/ef/core/testing/choosing-a-testing-strategy), I've experimented with using a production test database for unit testing the Service methods. The approach generally follows [this guide](https://docs.microsoft.com/en-us/ef/core/testing/testing-with-the-database), using a new `BricksAndHeartsTest` database.
> 
> - Non-committing transactions are used to maintain test isolation for write operations. This means any methods which use transactions themselves (i.e. `LandlordService.RegisterLandlordWithUser()`) probably can't be tested with this framework.
> - These tests will probably be run whenever a PR is made, but this environment doesn't seem to have a database, meaning they would likely fail. Is there a way to get around this? It seems like there's a way to [run SQL Server from GitHub Actions](https://datastation.multiprocess.io/blog/2021-12-16-sqlserver-in-github-actions.html).
> - Would we ever run the tests on the staging site? If so, would we need to set up this new testing database on Azure?
> 
> Is this a good approach? Or is there a better alternative?