### PR TITLE
BNH-12 Fix landlord registration exception caused by email

### DIFF
--- a/web/appsettings.json
+++ b/web/appsettings.json
@@ -19,7 +19,11 @@
     }
   },
   "Email": {
-    "FromAddress" : "tech@changeahead.org.uk",
+    "Host": "mail.epclients.co.uk",
+    "Port": 465,
+    "UserName": "tech@changeahead.org.uk",
+    "Password": "",
+    "FromAddress": "tech@changeahead.org.uk",
     "ToAddress": "tech@changeahead.org.uk"
   }
 }


### PR DESCRIPTION
As noted on [the ticket](https://softwiretech.atlassian.net/browse/BNH-12?atlOrigin=eyJpIjoiZmE3YmRmZTM2MDc5NDlkZTg4YTEyNTMwOTUxNjMyYWYiLCJwIjoiaiJ9), the `appsettings.json` was missing some fields required to send emails, which caused an unhandled exception during landlord registration on the staging site.

The fields have been added and tested successfully locally. The password has been added to Azure's application settings.