### PR TITLE
BNH-72 - success/failure message for charter approval

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
@@ -25,7 +25,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
     }
 
     [Fact]
-    public async void ApproveCharter_CallsApproveLandlord()
+    public async void ApproveCharter_CallsApproveLandlord_AndDisplaysSuccessMessage()
     {
         // Arrange
         var adminUser = CreateAdminUser();
@@ -37,6 +37,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
 
         // Assert
         A.CallTo(() => LandlordService.ApproveLandlord(landlord.Id, adminUser)).MustHaveHappened();
+        UnderTest.TempData["ApprovalSuccessMessage"].Should().Be("");
     }
     
     [Fact]

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
@@ -3,6 +3,8 @@ using BricksAndHearts.Controllers;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using FakeItEasy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 
 namespace BricksAndHearts.UnitTests.ControllerTests.Landlord;
@@ -21,7 +23,9 @@ public class LandlordControllerTestsBase : ControllerTestsBase
         LandlordService = A.Fake<ILandlordService>();
         Logger = A.Fake<Logger<LandlordController>>();
         MailService = A.Fake<MailService>();
-        UnderTest = new LandlordController(Logger, LandlordService, PropertyService, MailService);
+        var httpContext = new DefaultHttpContext();
+        var tempData = new TempDataDictionary(httpContext, A.Fake<ITempDataProvider>());
+        UnderTest = new LandlordController(Logger, LandlordService, PropertyService, MailService){TempData = tempData};
     }
     
     protected PropertyViewModel CreateExamplePropertyViewModel()

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -123,7 +123,7 @@ public class LandlordController : AbstractController
     public async Task<ActionResult> ApproveCharter(int landlordId)
     {
         var user = GetCurrentUser();
-        await _landlordService.ApproveLandlord(landlordId, user);
+        TempData["ApprovalSuccessMessage"] = await _landlordService.ApproveLandlord(landlordId, user);
         return RedirectToAction("Profile", "Landlord", new { Id = landlordId });
     }
 

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -19,7 +19,7 @@ public interface ILandlordService
     public Task<LandlordDbModel?> GetLandlordIfExistsFromId(int id);
     public Task<LandlordRegistrationResult> EditLandlordDetails(LandlordProfileModel editModel);
     public bool CheckForDuplicateEmail(LandlordProfileModel editModel);
-    public Task ApproveLandlord(int landlordId, BricksAndHeartsUser user);
+    public Task<string> ApproveLandlord(int landlordId, BricksAndHeartsUser user);
 
 }
 
@@ -83,21 +83,22 @@ public class LandlordService : ILandlordService
         return _dbContext.Landlords.SingleOrDefaultAsync(l => l.Id == id);
     }
 
-    public async Task ApproveLandlord(int landlordId,  BricksAndHeartsUser user)
+    public async Task<string> ApproveLandlord(int landlordId,  BricksAndHeartsUser user)
     {
         var landlord = await GetLandlordIfExistsFromId(landlordId);
         if (landlord is null)
         {
-            throw new Exception("Landlord does not exist");
+            return "Sorry, it appears that no landlord with this ID exists";
         }
         if (landlord.CharterApproved)
         {
-            throw new Exception("Landlord already approved");
+            return $"The Landlord Charter for {landlord.FirstName} {landlord.LastName} has already been approved.";
         }
         landlord.CharterApproved = true;
         landlord.ApprovalTime = DateTime.Now;
         landlord.ApprovalAdminId = user.Id;
         await _dbContext.SaveChangesAsync();
+        return $"Successfully approved Landlord Charter for {landlord.FirstName} {landlord.LastName}.";
     }
     
     public async Task<ILandlordService.LandlordRegistrationResult> EditLandlordDetails(LandlordProfileModel editModel)

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -34,6 +34,14 @@
             </div>
         }
     }
+    @{
+        if (TempData["ApprovalSuccessMessage"] != null)
+        {
+            <div class="alert alert-warning" role="alert">
+                @TempData["ApprovalSuccessMessage"]
+            </div>
+        }
+    }
     <h4>Landlord</h4>
     
     <hr/>


### PR DESCRIPTION
When an admin approves the charter of a landlord, the landlord's profile reloads with a message indicating that either
 - the charter has been successfully approved (in which case database changes will also have occurred)
 - the charter was previously approved
 - the landlord does not appear to exist (the image below was generated by temporarily hard-coding an error)
![image](https://user-images.githubusercontent.com/108676120/182176034-0fe30da1-f0e4-436f-87bc-9139a99390f5.png)
![image](https://user-images.githubusercontent.com/108676120/182176050-925dded1-7b79-4d69-8edf-9002e0af22b8.png)
![image](https://user-images.githubusercontent.com/108676120/182176229-80f5efe1-fcbc-433c-b5ca-360703dfb717.png)