### PR TITLE
BNH-45 Admin edit landlord profile

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
@@ -1,3 +1,4 @@
+using BricksAndHearts.Database;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using FakeItEasy;
@@ -40,6 +41,51 @@ public class LandlordControllerTests : LandlordControllerTestsBase
     }
     
     [Fact]
+    public void EditProfilePage_CalledUsingUserId_ReturnsEditProfileViewWithLandlordProfile()
+    {
+        // Arrange 
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        var landlordProfileModel = CreateTestLandlordProfileModel();
+
+        // Act
+        var result = UnderTest.EditProfilePage(landlordProfileModel.LandlordId).Result as ViewResult;
+
+        // Assert   
+        result!.Model.Should().BeOfType<LandlordProfileModel>();
+    }
+    
+    [Fact]
+    public void EditProfilePage_CalledUsingInvalidId_Returns404Error()
+    {
+        // Arrange 
+        var adminUser = CreateAdminUser();
+        LandlordDbModel? fakeNullLandlord = null;
+        MakeUserPrincipalInController(adminUser, UnderTest);
+
+        // Act
+        A.CallTo(() => LandlordService.GetLandlordIfExistsFromId(A<int>._)).Returns(fakeNullLandlord);
+        var result = UnderTest.EditProfilePage(1000).Result;
+
+        // Assert   
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(404);
+    }
+    
+    [Fact]
+    public void EditProfilePage_CalledUsingNonAdmin_Returns403Error()
+    {
+        // Arrange 
+        var landlordUser = CreateLandlordUser();
+        MakeUserPrincipalInController(landlordUser, UnderTest);
+
+        // Act
+        var result = UnderTest.EditProfilePage(1000).Result;
+
+        // Assert   
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(403);
+    }
+    
+    [Fact]
     public void EditProfileUpdate_CalledUsingLandlordDatabaseModel_ReturnsProfileViewWithLandlordProfile()
     {
         // Arrange 
@@ -74,17 +120,33 @@ public class LandlordControllerTests : LandlordControllerTestsBase
     }
     
     [Fact]
-    public void EditProfilePage_CalledUsingUserEmail_ReturnsEditProfileViewWithLandlordProfile()
+    public void EditProfileUpdate_CalledUsingNonAdmin_Returns403Error()
     {
-        // Arrange 
-        var adminUser = CreateAdminUser();
-        MakeUserPrincipalInController(adminUser, UnderTest);
-        var landlordProfileModel = CreateTestLandlordProfileModel();
+        // Arrange
+        var landlordUser = CreateLandlordUser();
+        MakeUserPrincipalInController(landlordUser, UnderTest);
+        var invalidLandlordModel = CreateInvalidLandlordProfileModel();
 
         // Act
-        var result = UnderTest.EditProfilePage(landlordProfileModel.LandlordId).Result as ViewResult;
+        var result = UnderTest.EditProfileUpdate(invalidLandlordModel).Result;
 
         // Assert   
-        result!.Model.Should().BeOfType<LandlordProfileModel>();
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(403);
+    }
+    
+    [Fact]
+    public void EditProfileUpdate_CalledUsingInvalidModel_Returns404Error()
+    {
+        // Arrange
+        var landlordUser = CreateLandlordUser();
+        MakeUserPrincipalInController(landlordUser, UnderTest);
+        UnderTest.ModelState.AddModelError("Invalid","this is a pretend error");
+        var invalidLandlordModel = CreateInvalidLandlordProfileModel();
+
+        // Act
+        var result = UnderTest.EditProfileUpdate(invalidLandlordModel).Result;
+
+        // Assert   
+        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(404);
     }
 }

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
@@ -60,4 +60,18 @@ public class LandlordControllerTestsBase : ControllerTestsBase
             LandlordProvidedCharterStatus = false
         };
     }
+
+    protected LandlordProfileModel CreateInvalidLandlordProfileModel()
+    {
+        return new LandlordProfileModel()
+        {
+            LandlordId = 1000,
+            Title = "MRMRMRMRMRMRMRMRMRMRMRMRMRMRMRMRMRMRMRMRMRMRMRMRMRfiftyMRMRMRMRMRMRMRMRMRMRseventy",
+            LastName = "Doe",
+            CompanyName = "John Doe",
+            CharterApproved = false,
+            LandlordStatus = "some data",
+            LandlordProvidedCharterStatus = false
+        };
+    }
 }

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -143,7 +143,7 @@ public class LandlordController : AbstractController
     }
 
     [HttpGet]
-    [Route("edit")]
+    [Route("{landlordId:int}/edit")]
     public async Task<ActionResult> EditProfilePage(int landlordId)
     {
         var user = GetCurrentUser();
@@ -158,6 +158,7 @@ public class LandlordController : AbstractController
     public async Task<ActionResult> EditProfileUpdate([FromForm] LandlordProfileModel editModel)
     {
         var user = GetCurrentUser();
+        if (!ModelState.IsValid) return StatusCode(404);
         if (user.LandlordId != editModel.LandlordId && !user.IsAdmin) return StatusCode(403);
         var isEmailDuplicated = _landlordService.CheckForDuplicateEmail(editModel);
         if (isEmailDuplicated)


### PR DESCRIPTION
Admins can now edit landlord profiles by clicking / typing in the route in a similar way to navigating to the profiles. Also added a check that the profile passed into the edit method is properly defined. Wrote additional unit tests.