### PR TITLE
BNH-87 fixing BNH-17: edit page tabbing wrong

### DIFF
--- a/web/wwwroot/js/registerPageScript.js
+++ b/web/wwwroot/js/registerPageScript.js
@@ -5,7 +5,7 @@ let inputs, currentInput
 
 inputs = document.getElementsByTagName('input');
 // Execute a function when the user presses a key on the keyboard
-window.addEventListener("keyup", function (event) {
+window.addEventListener("keydown", function (event) {
     // If the user presses the "Enter" key on the keyboard
     if (event.key === "Enter") {
         // Cancel the default action, if needed
@@ -20,6 +20,7 @@ window.addEventListener("keyup", function (event) {
 });
 if(localStorage.getItem("storedCurrentTab")!=null){
     currentTab = parseInt(localStorage.getItem("storedCurrentTab"));
+    localStorage.setItem("storedCurrentTab", "0");
 }
 showTab(currentTab);
 


### PR DESCRIPTION
Reset local storage to default after use so that the next time you go to a page it is the default page unless otherwise specified, changed the enter keylistener to keydown instead of keyup to prevent the page being moved on when typing into the address bar