### PR TITLE
BNH 80 - add membershipId

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
@@ -119,6 +119,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         MakeUserPrincipalInController(adminUser, UnderTest);
         var landlordProfileModel = CreateTestLandlordProfileModel();
         A.CallTo(() => LandlordService.CheckForDuplicateEmail(landlordProfileModel)).Returns(false);
+        A.CallTo(() => LandlordService.CheckForDuplicateMembershipId(landlordProfileModel)).Returns(false);
         A.CallTo(() => LandlordService.EditLandlordDetails(landlordProfileModel))
             .Returns(ILandlordService.LandlordRegistrationResult.Success);
 
@@ -138,6 +139,26 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         MakeUserPrincipalInController(adminUser, UnderTest);
         var landlordProfileModel = CreateTestLandlordProfileModel();
         A.CallTo(() => LandlordService.CheckForDuplicateEmail(landlordProfileModel)).Returns(true);
+        A.CallTo(() => LandlordService.CheckForDuplicateMembershipId(landlordProfileModel)).Returns(false);
+
+        // Act
+        var result = UnderTest.EditProfileUpdate(landlordProfileModel).Result as ViewResult;
+
+        // Assert   
+        result!.Model.Should().BeOfType<LandlordProfileModel>();
+        result.Should().BeOfType<ViewResult>().Which.ViewName!.Should().BeEquivalentTo("EditProfilePage");
+    }
+    
+    [Fact]
+    public void
+        EditProfileUpdate_CalledUsingLandlordDatabaseModelWithDuplicateMembershipId_ReturnsEditProfileViewWithLandlordProfile()
+    {
+        // Arrange 
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        var landlordProfileModel = CreateTestLandlordProfileModel();
+        A.CallTo(() => LandlordService.CheckForDuplicateEmail(landlordProfileModel)).Returns(false);
+        A.CallTo(() => LandlordService.CheckForDuplicateMembershipId(landlordProfileModel)).Returns(true);
 
         // Act
         var result = UnderTest.EditProfileUpdate(landlordProfileModel).Result as ViewResult;

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -96,6 +96,11 @@ public class LandlordController : AbstractController
                 _logger.LogWarning("Email already registered {Email}", createModel.Email);
                 ModelState.AddModelError("Email", "Email already registered");
                 return View("Register", createModel);
+            
+            case ILandlordService.LandlordRegistrationResult.ErrorLandlordMembershipIdAlreadyRegistered:
+                _logger.LogWarning("Membership Id already registered {MembershipId}", createModel.MembershipId);
+                ModelState.AddModelError("MembershipId", "Membership Id already registered");
+                return View("Register", createModel);
 
             case ILandlordService.LandlordRegistrationResult.ErrorUserAlreadyHasLandlordRecord:
                 _logger.LogWarning("User {UserId} already associated with landlord", user.Id);

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -240,6 +240,14 @@ public class LandlordController : AbstractController
             ModelState.AddModelError("Email", "Email already registered");
             return View("EditProfilePage", editModel);
         }
+        
+        var isMembershipIdDuplicated = _landlordService.CheckForDuplicateMembershipId(editModel);
+        if (isMembershipIdDuplicated)
+        {
+            _logger.LogWarning("Membership Id already registered {MembershipId}", editModel.MembershipId);
+            ModelState.AddModelError("MembershipId", "Membership Id already registered");
+            return View("EditProfilePage", editModel);
+        }
 
         await _landlordService.EditLandlordDetails(editModel);
         _logger.LogInformation("Successfully edited landlord for landlord {LandlordId}", editModel.LandlordId);

--- a/web/Database/LandlordDbModel.cs
+++ b/web/Database/LandlordDbModel.cs
@@ -18,6 +18,8 @@ public class LandlordDbModel
 
     //Whether the landlord claims to have signed the charter
     public bool LandlordProvidedCharterStatus { get; set; } = false;
+    
+    public string? MembershipId { get; set; }
 
     //Whether the charter has been approved by an admin
     public bool CharterApproved { get; set; } = false;

--- a/web/Migrations/20220802124217_AddMembershipId.Designer.cs
+++ b/web/Migrations/20220802124217_AddMembershipId.Designer.cs
@@ -4,6 +4,7 @@ using BricksAndHearts.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BricksAndHearts.Migrations
 {
     [DbContext(typeof(BricksAndHeartsDbContext))]
-    partial class BricksAndHeartsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220802124217_AddMembershipId")]
+    partial class AddMembershipId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -53,13 +55,10 @@ namespace BricksAndHearts.Migrations
                     b.Property<string>("InviteLink")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("IsLandlordForProfit")
-                        .HasColumnType("bit");
-
                     b.Property<bool>("LandlordProvidedCharterStatus")
                         .HasColumnType("bit");
 
-                    b.Property<string>("LandlordType")
+                    b.Property<string>("LandlordStatus")
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
@@ -90,27 +89,6 @@ namespace BricksAndHearts.Migrations
                         .HasColumnType("int");
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
-
-                    b.Property<bool?>("AcceptsBenefits")
-                        .HasColumnType("bit");
-
-                    b.Property<bool?>("AcceptsCouple")
-                        .HasColumnType("bit");
-
-                    b.Property<bool?>("AcceptsFamily")
-                        .HasColumnType("bit");
-
-                    b.Property<bool?>("AcceptsNotEET")
-                        .HasColumnType("bit");
-
-                    b.Property<bool?>("AcceptsPets")
-                        .HasColumnType("bit");
-
-                    b.Property<bool?>("AcceptsSingleTenant")
-                        .HasColumnType("bit");
-
-                    b.Property<bool?>("AcceptsWithoutGuarantor")
-                        .HasColumnType("bit");
 
                     b.Property<string>("AddressLine1")
                         .IsRequired()

--- a/web/Migrations/20220802124217_AddMembershipId.cs
+++ b/web/Migrations/20220802124217_AddMembershipId.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BricksAndHearts.Migrations
+{
+    public partial class AddMembershipId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MembershipId",
+                table: "Landlord",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MembershipId",
+                table: "Landlord");
+        }
+    }
+}

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -32,6 +32,7 @@ public interface ILandlordService
     public Task<LandlordDbModel?> GetLandlordIfExistsFromId(int? id);
     public Task<LandlordRegistrationResult> EditLandlordDetails(LandlordProfileModel editModel);
     public bool CheckForDuplicateEmail(LandlordProfileModel editModel);
+    public bool CheckForDuplicateMembershipId(LandlordProfileModel editModel);
     public Task<string> ApproveLandlord(int landlordId, BricksAndHeartsUser user);
     public LandlordDbModel? FindLandlordWithInviteLink(string inviteLink);
 
@@ -206,6 +207,15 @@ public class LandlordService : ILandlordService
         landlordToEdit.Phone = editModel.Phone;
         landlordToEdit.LandlordType = editModel.LandlordType;
         landlordToEdit.IsLandlordForProfit = editModel.IsLandlordForProfit;
+        landlordToEdit.LandlordProvidedCharterStatus = editModel.LandlordProvidedCharterStatus;
+        if (editModel.LandlordProvidedCharterStatus)
+        {
+            landlordToEdit.MembershipId = editModel.MembershipId;
+        }
+        else
+        {
+            landlordToEdit.MembershipId = null;
+        }
 
         await _dbContext.SaveChangesAsync();
         return ILandlordService.LandlordRegistrationResult.Success;
@@ -216,6 +226,17 @@ public class LandlordService : ILandlordService
         var editedLandlord = _dbContext.Landlords.Single(l => l.Id == editModel.LandlordId);
         return _dbContext.Landlords.SingleOrDefault(l => l.Email == editModel.Email) != null
                && editedLandlord.Email != editModel.Email;
+    }
+    
+    public bool CheckForDuplicateMembershipId(LandlordProfileModel editModel)
+    {
+        var editedLandlord = _dbContext.Landlords.Single(l => l.Id == editModel.LandlordId);
+        if (!editModel.LandlordProvidedCharterStatus)
+        {
+            return false;
+        }
+        return _dbContext.Landlords.SingleOrDefault(l => l.MembershipId == editModel.MembershipId) != null
+               && editedLandlord.MembershipId != editModel.MembershipId;
     }
     
     // Link existing landlord with user

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -10,6 +10,7 @@ public interface ILandlordService
 {
     public enum LandlordRegistrationResult
     {
+        ErrorLandlordMembershipIdAlreadyRegistered,
         ErrorLandlordEmailAlreadyRegistered,
         ErrorUserAlreadyHasLandlordRecord,
         Success
@@ -63,8 +64,12 @@ public class LandlordService : ILandlordService
             Phone = createModel.Phone,
             LandlordType = createModel.LandlordType,
             IsLandlordForProfit = createModel.IsLandlordForProfit,
-            LandlordProvidedCharterStatus = createModel.LandlordProvidedCharterStatus
+            LandlordProvidedCharterStatus = createModel.LandlordProvidedCharterStatus,
         };
+        if (createModel.LandlordProvidedCharterStatus)
+        {
+            dbModel.MembershipId = createModel.MembershipId;
+        }
 
         await using (var transaction = await _dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable))
         {
@@ -73,6 +78,15 @@ public class LandlordService : ILandlordService
             if (await _dbContext.Landlords.AnyAsync(l => l.Email == createModel.Email))
             {
                 return (ILandlordService.LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered, null);
+            }
+            
+            // If the landlord has a membershipId, check there isn't already a Landlord with that membershipId.
+            if (dbModel.MembershipId != null)
+            {
+                if (await _dbContext.Landlords.AnyAsync(l => l.MembershipId == dbModel.MembershipId))
+                {
+                    return (ILandlordService.LandlordRegistrationResult.ErrorLandlordMembershipIdAlreadyRegistered, null);
+                }
             }
 
             // Check the user doesn't already have a landlord associated
@@ -115,8 +129,12 @@ public class LandlordService : ILandlordService
             Phone = createModel.Phone,
             LandlordType = createModel.LandlordType,
             IsLandlordForProfit = createModel.IsLandlordForProfit,
-            LandlordProvidedCharterStatus = createModel.LandlordProvidedCharterStatus
+            LandlordProvidedCharterStatus = createModel.LandlordProvidedCharterStatus,
         };
+        if (createModel.LandlordProvidedCharterStatus)
+        {
+            dbModel.MembershipId = createModel.MembershipId;
+        }
         await using (var transaction = await _dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable))
         {
             // Check there isn't already a Landlord with that email. Nothing depends on this currently, but it would probably mean the landlord is a duplicate
@@ -124,6 +142,15 @@ public class LandlordService : ILandlordService
             if (await _dbContext.Landlords.AnyAsync(l => l.Email == createModel.Email))
             {
                 return (ILandlordService.LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered, null);
+            }
+            
+            // If the landlord has a membershipId, check there isn't already a Landlord with that membershipId.
+            if (dbModel.MembershipId != null)
+            {
+                if (await _dbContext.Landlords.AnyAsync(l => l.MembershipId == dbModel.MembershipId))
+                {
+                    return (ILandlordService.LandlordRegistrationResult.ErrorLandlordMembershipIdAlreadyRegistered, null);
+                }
             }
 
             // Insert the landlord and call SaveChanges

--- a/web/ViewModels/LandlordProfileModel.cs
+++ b/web/ViewModels/LandlordProfileModel.cs
@@ -41,6 +41,8 @@ public class LandlordProfileModel
 
     public bool LandlordProvidedCharterStatus { get; set; }
 
+    public string? MembershipId { get; set; }
+    
     public bool CharterApproved { get; set; }
 
     public bool CurrentUserIsAdmin { get; set; }
@@ -63,6 +65,7 @@ public class LandlordProfileModel
             Title = landlord.Title,
             LandlordType = landlord.LandlordType,
             LandlordProvidedCharterStatus = landlord.LandlordProvidedCharterStatus,
+            MembershipId = landlord.MembershipId,
             CharterApproved = landlord.CharterApproved,
             IsLandlordForProfit = landlord.IsLandlordForProfit,
             CurrentUserIsAdmin = user.IsAdmin

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -112,20 +112,27 @@
         }
     </div>
     <div class="col-lg-5">
-        <h4>ChangeAhead Charter</h4>
+        <div class="d-flex p-2 justify-content-between">
+            <h4>ChangeAhead Charter</h4>
+            <td>
+                <input type="button" class="btn btn-outline-primary" value="Edit" onclick="location.href='@Url.Action("EditProfilePage", new { landlordId = Model.LandlordId })'; setCurrentTab(3);"/>
+            </td>
+        </div>
         @if (Model.CharterApproved)
         {
             <p>Charter status: Approved</p>
+            <p>Membership Id: @Model.MembershipId</p>
         }
         else
         {
             <p>Charter status: Pending</p>
-            @if (Model.CurrentUserIsAdmin)
+            @if (Model.CurrentUserIsAdmin && Model.MembershipId != null)
             {
+                <p>Membership Id: @Model.MembershipId</p>
                 @using (Html.BeginForm("ApproveCharter", "Landlord", FormMethod.Post))
                 {
                     <input type="hidden" id="landlordId" name="landlordId" value=@Model.LandlordId>
-                    <button type="submit" class="btn btn-outline-primary">Approve Landlord</button>
+                    <button type="submit" class="btn btn-outline-primary">Confirm Landlord Charter Membership</button>
                 }
             }
         }

--- a/web/Views/Shared/_RegisterPagePartial.cshtml
+++ b/web/Views/Shared/_RegisterPagePartial.cshtml
@@ -64,22 +64,6 @@
 </div>
 
 <div class="registerTab" id="ChangeAhead status" >
-   
-    @if (Model.LandlordProvidedCharterStatus)
-    {
-        <style>
-            div.hidetrue {}
-            div.hidefalse {display: none;}
-        </style>
-    }
-    else
-    {
-        <style>
-            div.hidetrue {display: none;}
-            div.hidefalse {}
-        </style>
-    }
-    
     <p>ChangeAhead Charter</p>
 
     <div class="my-3">
@@ -93,12 +77,12 @@
         <span asp-validation-for="LandlordProvidedCharterStatus" class="text-danger"></span>
     </div>
 
-    <div id="ifTrue" class="form-group my-3 hidetrue">
+    <div id="ifTrue" class="form-group my-3" style="@(Model.LandlordProvidedCharterStatus ? "" : "display: none;")">
         <label class="control-label">Please provide your Charter Membership Id:</label>
         <input asp-for="MembershipId" class="form-control empty"/>
         <span asp-validation-for="MembershipId" class="text-danger"></span>
     </div>
-    <div id="ifFalse" class="hidefalse">
+    <div id="ifFalse" style="@(!Model.LandlordProvidedCharterStatus ? "" : "display: none;")">
         ChangeAhead require your participation in a charter system.
     </div>
 </div>

--- a/web/Views/Shared/_RegisterPagePartial.cshtml
+++ b/web/Views/Shared/_RegisterPagePartial.cshtml
@@ -1,4 +1,4 @@
-﻿@model LandlordProfileModel
+@model LandlordProfileModel
 <div class="registerTab" id="Name">
     <div class="form-group my-3">
         <label>Title:</label>
@@ -63,15 +63,44 @@
     </div>
 </div>
 
-<div class="registerTab" id="ChangeAhead status">
-    <p>ChangeAhead Charter</p>
-    <p>What is your ChangeAhead Charter status?</p>
-
-    @Html.DropDownList("CharterStatus", new List<SelectListItem>
+<div class="registerTab" id="ChangeAhead status" >
+   
+    @if (Model.LandlordProvidedCharterStatus)
     {
-        new() { Text = "Already approved", Value = "true", Selected = true },
-        new() { Text = "Not yet approved", Value = "false" }
-    })
+        <style>
+            div.hidetrue {}
+            div.hidefalse {display: none;}
+        </style>
+    }
+    else
+    {
+        <style>
+            div.hidetrue {display: none;}
+            div.hidefalse {}
+        </style>
+    }
+    
+    <p>ChangeAhead Charter</p>
+
+    <div class="my-3">
+        <label asp-for="LandlordProvidedCharterStatus" class="form-label">What is your ChangeAhead Charter status?</label>
+        <select asp-for="LandlordProvidedCharterStatus" class="form-select" required
+                id="Select" onclick="checkIfSelectedValueIsTarget()">
+            <option selected disabled value="">Charter Status</option>
+            <option value="true">Already approved</option>
+            <option value="false">Not yet approved</option>
+        </select>
+        <span asp-validation-for="LandlordProvidedCharterStatus" class="text-danger"></span>
+    </div>
+
+    <div id="ifTrue" class="form-group my-3 hidetrue">
+        <label class="control-label">Please provide your Charter Membership Id:</label>
+        <input asp-for="MembershipId" class="form-control empty"/>
+        <span asp-validation-for="MembershipId" class="text-danger"></span>
+    </div>
+    <div id="ifFalse" class="hidefalse">
+        ChangeAhead require your participation in a charter system.
+    </div>
 </div>
 
 <div class="registerTab" id="Terms and conditions">

--- a/web/wwwroot/js/registerPageScript.js
+++ b/web/wwwroot/js/registerPageScript.js
@@ -64,12 +64,17 @@ function validateForm() {
     // This function deals with validation of the form fields
     let tabList, tabInputList, tabInputIterator, valid = true;
     tabList = document.getElementsByClassName("registerTab");
-    tabInputList = tabList[currentTab].getElementsByTagName("input");
+    tabInputList = tabList[currentTab].querySelectorAll("input, select");
     // A loop that checks every input field in the current tab:
     for (tabInputIterator = 0; tabInputIterator < tabInputList.length; tabInputIterator++) {
         // Validation checks for the form
         let currentField = tabInputList[tabInputIterator]
+        if ((currentField.name === "MembershipId") && ((tabInputList[tabInputIterator-1]).value === "false"))
+        {
+           currentField.className = "form-control empty";
+        }
         if ((currentField.value === "" && currentField.className!=="form-control empty")
+            || ((currentField.name === "MembershipId") && (currentField.value === "") && ((tabInputList[tabInputIterator-1]).value === "true"))
             || (currentField.type === "email" && (currentField.value.indexOf("@") === -1))
             || (currentField.type === "tel" && !Number.isInteger(Number(currentField.value.replace(/\+/g,"")))))
         {

--- a/web/wwwroot/js/site.js
+++ b/web/wwwroot/js/site.js
@@ -6,3 +6,17 @@
 function setValue(elementId, value) {
     document.getElementById(elementId).value = value;
 }
+
+function checkIfSelectedValueIsTarget(){
+    if ($("#Select :selected").val() == "true")
+    {
+        $("#ifTrue").show();
+        $("#ifFalse").hide();
+    }
+    else
+    {
+        $("#ifTrue").hide();
+        $("#ifFalse").show();
+    }
+}
+


### PR DESCRIPTION
Adds Membership Id to the landlord registration and edit forms as a field which is displayed and required only if the Charter Status 'Already Approved' is selected (LandlordProvidedCharterStatus==true); otherwise, any input into the MembershipId field is ignored.
MembershipId is displayed in the ChangeAhead Charter section of the profile, if it has been provided; the button to 'Confirm Landlord Charter Membership' for Pending landlords only appears if there is a membership Id. Currently, however, the database will allow landlords without a Membership Id to be in an approved state - this is just not possible by following links through the website.