### PR TITLE
Bnh 94&95 - bug fixes on image upload

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
@@ -334,7 +334,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
     }
     
     [Fact]
-    public async void AddPropertyImages_CallsUploadImageForEachImage_AndRedirectsToListImages()
+    public async void AddPropertyImages_CallsUploadImageForEachImage_AndRedirectsToListImagesWithFlashMessage()
     {
         // Arrange
         var adminUser = CreateAdminUser();
@@ -343,6 +343,8 @@ public class PropertyControllerTests : PropertyControllerTestsBase
 
         var fakeImage = CreateExampleImage();
         var fakeImage2 = CreateExampleImage();
+        A.CallTo(() => AzureStorage.IsImage(fakeImage.FileName)).Returns(true);
+        A.CallTo(() => AzureStorage.IsImage(fakeImage2.FileName)).Returns(true);
         var fakeImageList = new List<IFormFile>{fakeImage, fakeImage2};
         
         // Act
@@ -352,8 +354,9 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         A.CallTo(() => AzureStorage.UploadFile(fakeImage, "property", 1)).MustHaveHappened();
         A.CallTo(() => AzureStorage.UploadFile(fakeImage2, "property", 1)).MustHaveHappened();
         result.Should().BeOfType<RedirectToActionResult>().Which.ActionName.Should().Be("ListPropertyImages");
+        UnderTest.TempData["FlashMessage"].Should().Be("");
     }
-    
+
     [Fact]
     public async void DisplayImage_CallsDownloadFileAsync_AndReturnsFile()
     {

--- a/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTestsBase.cs
@@ -6,6 +6,7 @@ using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using FakeItEasy;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 
 namespace BricksAndHearts.UnitTests.ControllerTests.Property;
@@ -24,7 +25,9 @@ public class PropertyControllerTestsBase : ControllerTestsBase
         AzureMapsApiService = A.Fake<IAzureMapsApiService>();
         AzureStorage = A.Fake<IAzureStorage>();
         Logger = A.Fake<ILogger<PropertyController>>();
-        UnderTest = new PropertyController(PropertyService, AzureMapsApiService, Logger, AzureStorage);
+        var httpContext = new DefaultHttpContext();
+        var tempData = new TempDataDictionary(httpContext, A.Fake<ITempDataProvider>());
+        UnderTest = new PropertyController(PropertyService, AzureMapsApiService, Logger, AzureStorage){TempData = tempData};
     }
 
     protected PropertyViewModel CreateExamplePropertyViewModel()

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Eventing.Reader;
 using System.Text.RegularExpressions;
 using BricksAndHearts.Database;
 using BricksAndHearts.Services;
@@ -195,7 +196,8 @@ public class PropertyController : AbstractController
             if (!_azureStorage.IsImage(image.FileName))
             {
                 FlashMessage(_logger,
-                    ($"File {image.FileName} not in a recognised image format", "danger", $"{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: JPG, JPEG, PNG, BMP, GIF"));
+                    ($"Failed to upload {image.FileName}: not in a recognised image format", "danger",
+                        "{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: JPG, JPEG, PNG, BMP, GIF"));
             }
             else
             {
@@ -208,7 +210,7 @@ public class PropertyController : AbstractController
                 else
                 {
                     FlashMessage(_logger,
-                        ($"File {image.FileName} has length zero", "danger", $"{image.FileName} contains no data, and so has not been uploaded"));
+                        ($"Failed to upload {image.FileName}: has length zero.", "danger", $"{image.FileName} contains no data, and so has not been uploaded"));
                 }
             }
         }

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -197,7 +197,7 @@ public class PropertyController : AbstractController
             {
                 FlashMessage(_logger,
                     ($"Failed to upload {image.FileName}: not in a recognised image format", "danger",
-                        "{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: JPG, JPEG, PNG, BMP, GIF"));
+                        $"{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: JPG, JPEG, PNG, BMP, GIF"));
             }
             else
             {

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -192,16 +192,24 @@ public class PropertyController : AbstractController
         }
         foreach (var image in images)
         {
-            if (image.Length > 0)
+            if (!_azureStorage.IsImage(image.FileName))
             {
-                await _azureStorage.UploadFile(image, "property", propertyId);
+                FlashMessage(_logger,
+                    ($"File {image.FileName} not in a recognised image format", "danger", $"{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: JPG, JPEG, PNG, BMP, GIF"));
             }
             else
             {
-                FlashMessage(_logger,
-                    ($"File {image.FileName} has length zero",
-                        "danger",
-                        "File contains no data"));
+                if (image.Length > 0)
+                {
+                    string message = await _azureStorage.UploadFile(image, "property", propertyId);
+                    FlashMessage(_logger,
+                        ($"Successfully uploaded {image.FileName}", "success", message));
+                }
+                else
+                {
+                    FlashMessage(_logger,
+                        ($"File {image.FileName} has length zero", "danger", $"{image.FileName} contains no data, and so has not been uploaded"));
+                }
             }
         }
         return RedirectToAction("ListPropertyImages", "Property", new{propertyId});

--- a/web/Services/AzureStorage.cs
+++ b/web/Services/AzureStorage.cs
@@ -119,7 +119,7 @@ namespace BricksAndHearts.Services
         {
             string fileType = SplitFileName(fileName).type;
             List<string> imageExtensions = new List<string> { "jpg", "jpeg", "png", "bmp", "gif" };
-            if (imageExtensions.Contains(fileType))
+            if (imageExtensions.Contains(fileType.ToLower()))
             {
                 return true;
             }

--- a/web/Services/AzureStorage.cs
+++ b/web/Services/AzureStorage.cs
@@ -70,10 +70,10 @@ namespace BricksAndHearts.Services
 
             if (blob.FileName != fileName)
             {
-                return $"Successfully uploaded {blob.FileName} with name {fileName}";
+                return $"Successfully uploaded {blob.FileName} with name {fileName}.";
             }
 
-            return $"Successfully uploaded {blob.FileName}";
+            return $"Successfully uploaded {blob.FileName}.";
         }
 
         public async Task<ImageListViewModel> ListFiles(string varType, int id)

--- a/web/Services/AzureStorage.cs
+++ b/web/Services/AzureStorage.cs
@@ -7,10 +7,11 @@ namespace BricksAndHearts.Services
     public interface IAzureStorage
     {
         Task DeleteContainer(string varType, int id);
-        Task UploadFile(IFormFile file, string varType, int id);
+        Task<string> UploadFile(IFormFile file, string varType, int id);
         Task<ImageListViewModel> ListFiles(string varType, int id);
         Task<(Stream? data, string? fileType)> DownloadFile(string varType, int id, string blobFilename);
         Task DeleteFile(string varType, int id, string blobFilename);
+        public bool IsImage(string fileName);
     }
 
     public class AzureStorage : IAzureStorage
@@ -50,21 +51,29 @@ namespace BricksAndHearts.Services
             await containerClient.DeleteAsync();
         }
 
-        public async Task UploadFile(IFormFile blob, string varType, int id)
+        public async Task<string> UploadFile(IFormFile blob, string varType, int id)
         {
             var containerClient = await GetOrCreateContainerClient(varType, id);
             var blobClient = containerClient.GetBlobClient(blob.FileName);
+            string fileName = blob.FileName;
             int i = 0;
             while (blobClient.Exists())
             {
                 i += 1;
-                string fileName = SplitFileName(blob.FileName).name + i + "." + SplitFileName(blob.FileName).type;
+                fileName = SplitFileName(blob.FileName).name + i + "." + SplitFileName(blob.FileName).type;
                 blobClient = containerClient.GetBlobClient(fileName);
             }
             await using (Stream? data = blob.OpenReadStream())
             {
                 await blobClient.UploadAsync(data);
             }
+
+            if (blob.FileName != fileName)
+            {
+                return $"Successfully uploaded {blob.FileName} with name {fileName}";
+            }
+
+            return $"Successfully uploaded {blob.FileName}";
         }
 
         public async Task<ImageListViewModel> ListFiles(string varType, int id)
@@ -104,6 +113,17 @@ namespace BricksAndHearts.Services
             {
                 await blobClient.DeleteAsync();
             }
+        }
+        
+        public bool IsImage(string fileName)
+        {
+            string fileType = SplitFileName(fileName).type;
+            List<string> imageExtensions = new List<string> { "jpg", "jpeg", "png", "bmp", "gif" };
+            if (imageExtensions.Contains(fileType))
+            {
+                return true;
+            }
+            return false;
         }
 
         private (string name, string type) SplitFileName(string fileName)

--- a/web/Services/PropertyService.cs
+++ b/web/Services/PropertyService.cs
@@ -133,11 +133,6 @@ public class PropertyService : IPropertyService
 
         var propertyLandlordId = GetPropertyByPropertyId(propertyId)!.LandlordId;
         var userLandlordId = currentUser.LandlordId;
-        if (propertyLandlordId == userLandlordId)
-        {
-            return true;
-        }
-
-        return false;
+        return propertyLandlordId == userLandlordId;
     }
 }

--- a/web/Views/Property/ListPropertyImages.cshtml
+++ b/web/Views/Property/ListPropertyImages.cshtml
@@ -14,7 +14,7 @@
                 @using (Html.BeginForm("DisplayPropertyImage", "Property", FormMethod.Post))
                 {
                     <input type="hidden" id="propertyId" name="propertyId" value=@Model.PropertyId>
-                    <input type="hidden" id="fileName" name="fileName" value=@file>
+                    <input type="hidden" id="fileName" name="fileName" value="@file">
                     <button type="submit" class="btn btn-primary">Display @file</button>
                 }
             </td>

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -6,7 +6,8 @@
     --black: #000000;
     --paleBlue: #ECF2FF;
     --paleOrange: #FFEEEE;
-    --white: #FFFFFF
+    --white: #FFFFFF;
+    --red: #C0392B
 }
 
 html {
@@ -71,6 +72,11 @@ body {
     outline-color: var(--lightOrange);
     box-shadow: 0 0 0 3px var(--lightOrange);
     color: var(--white);
+}
+
+.btn-danger{
+    background-color: var(--red);
+    border-color: var(--red);
 }
 
 .form-control{


### PR DESCRIPTION
BNH-94: The issue was that when filenames contained spaces, the image wouldn't display. This turned out not to be due to Azure's naming conventions (which are reasonably standard for files) but due to the space being treated as a string delimiter. I have fixed this accordingly (there were some "" missing!).

BNH-95: Added server-side validation of the file type. Currently only JPG, JPEG, PNG, BMP and GIF will be accepted. If there are any other image types which are common enough to be needed, they can easily be added.

I also added some flash messages to indicate successful upload or failed upload due to empty/ non-image file.