### PR TITLE
BNH-48_Fix_2: Removing user's admin credentials from LandlordProfileModel

### DIFF
--- a/web/ViewModels/LandlordProfileModel.cs
+++ b/web/ViewModels/LandlordProfileModel.cs
@@ -42,10 +42,8 @@ public class LandlordProfileModel
     public bool LandlordProvidedCharterStatus { get; set; }
 
     public string? MembershipId { get; set; }
-    
-    public bool CharterApproved { get; set; }
 
-    public bool CurrentUserIsAdmin { get; set; }
+    public bool CharterApproved { get; set; }
 
     public bool Unassigned { get; set; }
 
@@ -67,8 +65,7 @@ public class LandlordProfileModel
             LandlordProvidedCharterStatus = landlord.LandlordProvidedCharterStatus,
             MembershipId = landlord.MembershipId,
             CharterApproved = landlord.CharterApproved,
-            IsLandlordForProfit = landlord.IsLandlordForProfit,
-            CurrentUserIsAdmin = user.IsAdmin
+            IsLandlordForProfit = landlord.IsLandlordForProfit
         };
     }
 
@@ -86,8 +83,7 @@ public class LandlordProfileModel
             LandlordType = landlord.LandlordType,
             LandlordProvidedCharterStatus = landlord.LandlordProvidedCharterStatus,
             CharterApproved = landlord.CharterApproved,
-            IsLandlordForProfit = landlord.IsLandlordForProfit,
-            CurrentUserIsAdmin = landlord.User?.IsAdmin ?? false
+            IsLandlordForProfit = landlord.IsLandlordForProfit
         };
     }
 }

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -74,8 +74,14 @@
                 <tr>
                     <td>@Html.DisplayNameFor(model => model.IsLandlordForProfit)</td>
                     <td>
-                        @if (Model.IsLandlordForProfit) { <text>For profit</text> }
-                        else { <text>Not for profit</text> }
+                        @if (Model.IsLandlordForProfit)
+                        {
+                            <text>For profit</text>
+                        }
+                        else
+                        {
+                            <text>Not for profit</text>
+                        }
                     </td>
                 </tr>
             </table>
@@ -126,7 +132,7 @@
         else
         {
             <p>Charter status: Pending</p>
-            @if (Model.CurrentUserIsAdmin && Model.MembershipId != null)
+            @if (User.IsInRole("Admin") && Model.MembershipId != null)
             {
                 <p>Membership Id: @Model.MembershipId</p>
                 @using (Html.BeginForm("ApproveCharter", "Landlord", FormMethod.Post))


### PR DESCRIPTION
Branched from BNH-48_Fix #92 to ensure it tidies up the references to admin status in there too, this is in response to Ben's comment on that pull request :)