### PR TITLE
BNH-98: Social media links on contactus open in new tabs

### DIFF
--- a/web/Views/Home/ContactUs.cshtml
+++ b/web/Views/Home/ContactUs.cshtml
@@ -1,27 +1,41 @@
 ﻿@model dynamic
 
 @{
-    @ViewData["Title"]
+    ViewData["Title"] = "Contact Us";
 }
 
 <div>
     <h1>Contact Us</h1>
     <br/>
     <div>
-        <a href="mailto:info@changeahead.org.uk"><i class="bi bi-envelope-fill"></i></a>
-        <a href="https://www.facebook.com/changeahead.org/"><i class="bi bi-facebook"></i></a>
-        <a href="https://twitter.com/changeaheaduk"><i class="bi bi-twitter"></i></a>
-        <a href="https://www.instagram.com/accounts/login/?next=/changeahead.org.uk/"><i class="bi bi-instagram"></i></a>
-        <a href="https://www.linkedin.com/company/changeaheaduk/"><i class="bi bi-linkedin"></i></a>
-        <a href="https://www.youtube.com/channel/UC0gZrrMIzBCfUMPnf4EOmzA"><i class="bi bi-youtube"></i></a>
-        <a href="https://www.tiktok.com/"><i class="bi bi-tiktok"></i></a>
+        <a class="icon-link" href="mailto:info@changeahead.org.uk">
+            <i class="bi bi-envelope-fill"></i>
+        </a>
+        <a class="icon-link" href="https://www.facebook.com/changeahead.org/" target="_blank">
+            <i class="bi bi-facebook"></i>
+        </a>
+        <a class="icon-link" href="https://twitter.com/changeaheaduk" target="_blank">
+            <i class="bi bi-twitter"></i>
+        </a>
+        <a class="icon-link" href="https://www.instagram.com/accounts/login/?next=/changeahead.org.uk/" target="_blank">
+            <i class="bi bi-instagram"></i>
+        </a>
+        <a class="icon-link" href="https://www.linkedin.com/company/changeaheaduk/" target="_blank">
+            <i class="bi bi-linkedin"></i>
+        </a>
+        <a class="icon-link" href="https://www.youtube.com/channel/UC0gZrrMIzBCfUMPnf4EOmzA" target="_blank">
+            <i class="bi bi-youtube"></i>
+        </a>
+        <a class="icon-link" href="https://www.tiktok.com/" target="_blank">
+            <i class="bi bi-tiktok"></i>
+        </a>
     </div>
     <br/>
     <strong>Please feel free to contact us if you have any queries:</strong>
     <p>Email: info@changeahead.org.uk</p>
     <p>Helpline: 03337 729 259 </p>
     <p>Postal address: 85 Great Portland Street, First Floor, London, W1W 7LT</p>
-    <p>Or visit the Change Ahead website: <a href="https://www.changeahead.org.uk/">https://www.changeahead.org.uk/</a></p>
+    <p>Or visit the Change Ahead website: <a href="https://www.changeahead.org.uk/" target="_blank">https://www.changeahead.org.uk/</a></p>
     <br/>
     @*TODO Populate this FAQ section with whatever questions and answers the client would like*@
     <strong>Frequently Asked Questions</strong>

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -1,4 +1,4 @@
-:root{
+:root {
     --blue: #3A67C7;
     --darkOrange: #DD5050;
     --orange: #FF5757;
@@ -38,35 +38,35 @@ body {
     display: table;
 }
 
-.btn-primary{
+.btn-primary {
     background-color: var(--orange);
     border-color: var(--orange);
 }
 
-.btn-outline-primary{
+.btn-outline-primary {
     border-color: var(--orange);
     color: var(--orange)
 }
 
-.btn-primary:hover{
+.btn-primary:hover {
     background-color: var(--darkOrange);
     border-color: var(--orange);
 }
 
-.btn-outline-primary:hover{
+.btn-outline-primary:hover {
     background-color: var(--darkOrange);
     border-color: var(--orange);
     color: var(--white);
 }
 
-.btn-primary:focus, .btn-primary:active, .btn-primary:active:focus{
+.btn-primary:focus, .btn-primary:active, .btn-primary:active:focus {
     background-color: var(--orange);
     border-color: var(--orange);
     outline-color: var(--lightOrange);
     box-shadow: 0 0 0 3px var(--lightOrange);
 }
 
-.btn-outline-primary:focus, .btn-outline-primary:active, .btn-outline-primary:active:focus{
+.btn-outline-primary:focus, .btn-outline-primary:active, .btn-outline-primary:active:focus {
     background-color: var(--orange);
     border-color: var(--orange);
     outline-color: var(--lightOrange);
@@ -79,7 +79,7 @@ body {
     border-color: var(--red);
 }
 
-.form-control{
+.form-control {
     border-color: var(--blue);
 }
 
@@ -107,7 +107,7 @@ input.invalid {
 
 /* Mark the steps that are finished and valid: */
 .step.finish {
-  background-color: var(--orange);
+    background-color: var(--orange);
     opacity: 50%;
 }
 
@@ -116,6 +116,7 @@ input.invalid {
     background-color: var(--orange);
     opacity: 100%;
 }
+
 /*End of javascript form styling*/
 
 .tables {
@@ -149,4 +150,8 @@ input.invalid {
 
 input:checked + .pill-check i {
     display: inline-block;
+}
+
+.icon-link {
+    text-decoration: none;
 }


### PR DESCRIPTION
 Removed underline from icon links.
 Links open in new tab, including changeahead website.
Added the missing tab title in for the contactus page.

The other change in the BNH-98 ticket (View properties -> Properties) max did as part of his Navbar changes/styling ticket so I didn't do it here.