### PR TITLE
BNH-108 feat: display multiple flash messages

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
@@ -334,7 +334,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
     }
     
     [Fact]
-    public async void AddPropertyImages_CallsUploadImageForEachImage_AndRedirectsToListImagesWithFlashMessage()
+    public async void AddPropertyImages_CallsUploadImageForEachImage_AndRedirectsToListImagesWithFlashMultipleMessages()
     {
         // Arrange
         var adminUser = CreateAdminUser();
@@ -343,8 +343,8 @@ public class PropertyControllerTests : PropertyControllerTestsBase
 
         var fakeImage = CreateExampleImage();
         var fakeImage2 = CreateExampleImage();
-        A.CallTo(() => AzureStorage.IsImage(fakeImage.FileName)).Returns(true);
-        A.CallTo(() => AzureStorage.IsImage(fakeImage2.FileName)).Returns(true);
+        A.CallTo(() => AzureStorage.IsImage(fakeImage.FileName)).Returns((true, null));
+        A.CallTo(() => AzureStorage.IsImage(fakeImage2.FileName)).Returns((true, null));
         var fakeImageList = new List<IFormFile>{fakeImage, fakeImage2};
         
         // Act
@@ -354,7 +354,6 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         A.CallTo(() => AzureStorage.UploadFile(fakeImage, "property", 1)).MustHaveHappened();
         A.CallTo(() => AzureStorage.UploadFile(fakeImage2, "property", 1)).MustHaveHappened();
         result.Should().BeOfType<RedirectToActionResult>().Which.ActionName.Should().Be("ListPropertyImages");
-        UnderTest.TempData["FlashMessage"].Should().Be("");
     }
 
     [Fact]

--- a/web/Controllers/AbstractController.cs
+++ b/web/Controllers/AbstractController.cs
@@ -30,4 +30,18 @@ public abstract class AbstractController : Controller
         TempData["FlashType"] = flash.flashtype;
         TempData["FlashMessage"] = flash.flashmessage;
     }
+    
+    protected void FlashMultipleMessages(ILogger logger, (List<string> logInfo, List<string> flashtypes, List<string> flashmessages) flashes)
+    {
+        var flashTypes = new List<string>();
+        var flashMessages = new List<string>();
+        for (int i = 0; i < flashes.logInfo.Count; i++)
+        {
+            logger.LogInformation(flashes.logInfo[i]);
+            flashTypes.Add(flashes.flashtypes[i]);
+            flashMessages.Add(flashes.flashmessages[i]);
+        }
+        TempData["MultipleFlashTypes"] = flashTypes;
+        TempData["MultipleFlashMessages"] = flashMessages;
+    }
 }

--- a/web/Controllers/AbstractController.cs
+++ b/web/Controllers/AbstractController.cs
@@ -31,16 +31,8 @@ public abstract class AbstractController : Controller
         TempData["FlashMessage"] = flash.flashmessage;
     }
     
-    protected void FlashMultipleMessages(ILogger logger, (List<string> logInfo, List<string> flashtypes, List<string> flashmessages) flashes)
+    protected void FlashMultipleMessages(List<string> flashTypes, List<string> flashMessages)
     {
-        var flashTypes = new List<string>();
-        var flashMessages = new List<string>();
-        for (int i = 0; i < flashes.logInfo.Count; i++)
-        {
-            logger.LogInformation(flashes.logInfo[i]);
-            flashTypes.Add(flashes.flashtypes[i]);
-            flashMessages.Add(flashes.flashmessages[i]);
-        }
         TempData["MultipleFlashTypes"] = flashTypes;
         TempData["MultipleFlashMessages"] = flashMessages;
     }

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -87,6 +87,7 @@ public class LandlordController : AbstractController
                               + $"Phone: {createModel.Phone}" + "\n";
                 var subject = "Bricks&Hearts - landlord registration notification";
 #pragma warning disable CS4014
+                
                 Task.Run(() => TrySendMsg(msgBody, subject));
 #pragma warning restore CS4014
 

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -191,29 +191,36 @@ public class PropertyController : AbstractController
         {
             return StatusCode(403);
         }
+
+        List<string> logInfo = new List<string>(),
+            flashTypes = new List<string>(),
+            flashMessages = new List<string>();
         foreach (var image in images)
         {
             if (!_azureStorage.IsImage(image.FileName))
             {
-                FlashMessage(_logger,
-                    ($"Failed to upload {image.FileName}: not in a recognised image format", "danger",
-                        $"{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: JPG, JPEG, PNG, BMP, GIF"));
+                logInfo.Add($"Failed to upload {image.FileName}: not in a recognised image format");
+                flashTypes.Add("danger");
+                flashMessages.Add($"{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: JPG, JPEG, PNG, BMP, GIF");
             }
             else
             {
                 if (image.Length > 0)
                 {
                     string message = await _azureStorage.UploadFile(image, "property", propertyId);
-                    FlashMessage(_logger,
-                        ($"Successfully uploaded {image.FileName}", "success", message));
+                    logInfo.Add($"Successfully uploaded {image.FileName}");
+                    flashTypes.Add("success");
+                    flashMessages.Add(message);
                 }
                 else
                 {
-                    FlashMessage(_logger,
-                        ($"Failed to upload {image.FileName}: has length zero.", "danger", $"{image.FileName} contains no data, and so has not been uploaded"));
+                    logInfo.Add($"Failed to upload {image.FileName}: has length zero.");
+                    flashTypes.Add("danger");
+                    flashMessages.Add($"{image.FileName} contains no data, and so has not been uploaded");
                 }
             }
         }
+        FlashMultipleMessages(_logger, (logInfo, flashTypes, flashMessages));
         return RedirectToAction("ListPropertyImages", "Property", new{propertyId});
     }
     

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -192,15 +192,14 @@ public class PropertyController : AbstractController
             return StatusCode(403);
         }
 
-        List<string> logInfo = new List<string>(),
-            flashTypes = new List<string>(),
+        List<string> flashTypes = new List<string>(),
             flashMessages = new List<string>();
         foreach (var image in images)
         {
             var isImageResult = _azureStorage.IsImage(image.FileName);
             if (!isImageResult.isImage)
             {
-                logInfo.Add($"Failed to upload {image.FileName}: not in a recognised image format");
+                _logger.LogInformation($"Failed to upload {image.FileName}: not in a recognised image format");
                 flashTypes.Add("danger");
                 flashMessages.Add($"{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: {isImageResult.imageExtString}");
             }
@@ -209,19 +208,19 @@ public class PropertyController : AbstractController
                 if (image.Length > 0)
                 {
                     string message = await _azureStorage.UploadFile(image, "property", propertyId);
-                    logInfo.Add($"Successfully uploaded {image.FileName}");
+                    _logger.LogInformation($"Successfully uploaded {image.FileName}");
                     flashTypes.Add("success");
                     flashMessages.Add(message);
                 }
                 else
                 {
-                    logInfo.Add($"Failed to upload {image.FileName}: has length zero.");
+                    _logger.LogInformation($"Failed to upload {image.FileName}: has length zero.");
                     flashTypes.Add("danger");
                     flashMessages.Add($"{image.FileName} contains no data, and so has not been uploaded");
                 }
             }
         }
-        FlashMultipleMessages(_logger, (logInfo, flashTypes, flashMessages));
+        FlashMultipleMessages(flashTypes, flashMessages);
         return RedirectToAction("ListPropertyImages", "Property", new{propertyId});
     }
     

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -197,11 +197,12 @@ public class PropertyController : AbstractController
             flashMessages = new List<string>();
         foreach (var image in images)
         {
-            if (!_azureStorage.IsImage(image.FileName))
+            var isImageResult = _azureStorage.IsImage(image.FileName);
+            if (!isImageResult.isImage)
             {
                 logInfo.Add($"Failed to upload {image.FileName}: not in a recognised image format");
                 flashTypes.Add("danger");
-                flashMessages.Add($"{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: JPG, JPEG, PNG, BMP, GIF");
+                flashMessages.Add($"{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: {isImageResult.imageExtString}");
             }
             else
             {

--- a/web/Services/AzureStorage.cs
+++ b/web/Services/AzureStorage.cs
@@ -124,12 +124,8 @@ namespace BricksAndHearts.Services
                 return (true, null);
             }
 
-            string imageExtString = "";
-            foreach (string imageExt in imageExtensions)
-            {
-                imageExtString += imageExt + ", ";
-            }
-            return (false, imageExtString.Substring(0, imageExtString.Length - 2));
+            string imageExtString = String.Join(", ", imageExtensions);
+            return (false, imageExtString);
         }
 
         private (string name, string type) SplitFileName(string fileName)

--- a/web/Services/AzureStorage.cs
+++ b/web/Services/AzureStorage.cs
@@ -11,7 +11,7 @@ namespace BricksAndHearts.Services
         Task<ImageListViewModel> ListFiles(string varType, int id);
         Task<(Stream? data, string? fileType)> DownloadFile(string varType, int id, string blobFilename);
         Task DeleteFile(string varType, int id, string blobFilename);
-        public bool IsImage(string fileName);
+        public (bool isImage, string? imageExtString) IsImage(string fileName);
     }
 
     public class AzureStorage : IAzureStorage
@@ -115,15 +115,21 @@ namespace BricksAndHearts.Services
             }
         }
         
-        public bool IsImage(string fileName)
+        public (bool, string?) IsImage(string fileName)
         {
             string fileType = SplitFileName(fileName).type;
             List<string> imageExtensions = new List<string> { "jpg", "jpeg", "png", "bmp", "gif" };
             if (imageExtensions.Contains(fileType.ToLower()))
             {
-                return true;
+                return (true, null);
             }
-            return false;
+
+            string imageExtString = "";
+            foreach (string imageExt in imageExtensions)
+            {
+                imageExtString += imageExt + ", ";
+            }
+            return (false, imageExtString.Substring(0, imageExtString.Length - 2));
         }
 
         private (string name, string type) SplitFileName(string fileName)

--- a/web/Views/Property/ListPropertyImages.cshtml
+++ b/web/Views/Property/ListPropertyImages.cshtml
@@ -4,6 +4,20 @@
     ViewData["Title"] = "Image List";
 }
 
+@{
+    if (TempData["MultipleFlashMessages"] != null)
+    {
+        var flashMessages = TempData["MultipleFlashMessages"] as string[];
+        var flashTypes = TempData["MultipleFlashTypes"] as string[];
+        for (int i = 0; i < flashMessages!.Length; i++)
+        {
+            <div class="alert alert-@flashTypes![i]" role="alert">
+            @flashMessages[i]
+            </div>
+        }
+    }
+}
+
 <h2>Images available for property @Model.PropertyId</h2>
 
 <table>


### PR DESCRIPTION
Multiple flash messages can now appear on the Image List page - one per file when multiple files are uploaded simultaneously.
![image](https://user-images.githubusercontent.com/108676120/182870584-098c9105-6862-4470-9410-ec50da493a84.png)
