### PR TITLE
BNH-114 Set membership ID when approving charter

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
@@ -57,13 +57,31 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         // Arrange
         var adminUser = CreateAdminUser();
         MakeUserPrincipalInController(adminUser, UnderTest);
-        var landlord = CreateLandlordUser();
+        var landlordUser = CreateLandlordUser();
+        var landlordProfile = new LandlordProfileModel { LandlordId = landlordUser.Id };
 
         // Act
-        var result = await UnderTest.ApproveCharter(landlord.Id) as ViewResult;
+        var result = await UnderTest.ApproveCharter(landlordProfile) as ViewResult;
 
         // Assert
-        A.CallTo(() => LandlordService.ApproveLandlord(landlord.Id, adminUser)).MustHaveHappened();
+        A.CallTo(() => LandlordService.ApproveLandlord(landlordUser.Id, adminUser, null)).MustHaveHappened();
+        UnderTest.TempData["FlashMessage"].Should().Be("");
+    }
+
+    [Fact]
+    public async void ApproveCharter_CallsApproveLandlord_AndUpdatesMembershipId()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        var landlordUser = CreateLandlordUser();
+        var landlordProfile = new LandlordProfileModel { LandlordId = landlordUser.Id, MembershipId = "abc" };
+
+        // Act
+        var result = await UnderTest.ApproveCharter(landlordProfile) as ViewResult;
+
+        // Assert
+        A.CallTo(() => LandlordService.ApproveLandlord(landlordUser.Id, adminUser, "abc")).MustHaveHappened();
         UnderTest.TempData["FlashMessage"].Should().Be("");
     }
 
@@ -149,7 +167,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         result!.Model.Should().BeOfType<LandlordProfileModel>();
         result.Should().BeOfType<ViewResult>().Which.ViewName!.Should().BeEquivalentTo("EditProfilePage");
     }
-    
+
     [Fact]
     public void
         EditProfileUpdate_CalledUsingLandlordDatabaseModelWithDuplicateMembershipId_ReturnsEditProfileViewWithLandlordProfile()

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
@@ -58,31 +58,33 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         var adminUser = CreateAdminUser();
         MakeUserPrincipalInController(adminUser, UnderTest);
         var landlordUser = CreateLandlordUser();
-        var landlordProfile = new LandlordProfileModel { LandlordId = landlordUser.Id };
+        var landlordProfile = new LandlordProfileModel { LandlordId = landlordUser.Id, MembershipId = "abc" };
+        A.CallTo(() => LandlordService.ApproveLandlord(landlordUser.Id, adminUser, "abc"))
+            .Returns(ILandlordService.ApproveLandlordResult.Success);
 
         // Act
-        var result = await UnderTest.ApproveCharter(landlordProfile) as ViewResult;
+        await UnderTest.ApproveCharter(landlordProfile);
 
         // Assert
-        A.CallTo(() => LandlordService.ApproveLandlord(landlordUser.Id, adminUser, null)).MustHaveHappened();
-        UnderTest.TempData["FlashMessage"].Should().Be("");
+        A.CallTo(() => LandlordService.ApproveLandlord(landlordUser.Id, adminUser, "abc")).MustHaveHappened();
+        UnderTest.TempData["FlashMessage"].Should().Be("Successfully approved landlord charter.");
     }
 
     [Fact]
-    public async void ApproveCharter_CallsApproveLandlord_AndUpdatesMembershipId()
+    public async void ApproveCharter_WithoutMembershipId_DisplaysErrorMessage()
     {
         // Arrange
         var adminUser = CreateAdminUser();
         MakeUserPrincipalInController(adminUser, UnderTest);
         var landlordUser = CreateLandlordUser();
-        var landlordProfile = new LandlordProfileModel { LandlordId = landlordUser.Id, MembershipId = "abc" };
+        var landlordProfile = new LandlordProfileModel { LandlordId = landlordUser.Id };
 
         // Act
-        var result = await UnderTest.ApproveCharter(landlordProfile) as ViewResult;
+        await UnderTest.ApproveCharter(landlordProfile);
 
         // Assert
-        A.CallTo(() => LandlordService.ApproveLandlord(landlordUser.Id, adminUser, "abc")).MustHaveHappened();
-        UnderTest.TempData["FlashMessage"].Should().Be("");
+        A.CallTo(() => LandlordService.ApproveLandlord(landlordUser.Id, adminUser, null!)).MustNotHaveHappened();
+        UnderTest.TempData["FlashMessage"].Should().Be("Membership ID is required.");
     }
 
     [Fact]

--- a/BricksAndHearts.UnitTests/ServiceTests/Landlord/LandlordServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Landlord/LandlordServiceTests.cs
@@ -102,7 +102,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         // Assert
         context.ChangeTracker.Clear();
 
-        result.Should().Be($"Successfully approved landlord charter for {landlord.FirstName} {landlord.LastName}.");
+        result.Should().Be(ILandlordService.ApproveLandlordResult.Success);
 
         landlord = context.Landlords.Single(l => l.Email == "test.landlord2@gmail.com");
         landlord.CharterApproved.Should().BeTrue();

--- a/BricksAndHearts.UnitTests/ServiceTests/Landlord/LandlordServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Landlord/LandlordServiceTests.cs
@@ -6,7 +6,6 @@ using BricksAndHearts.Auth;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using FluentAssertions;
-using Org.BouncyCastle.Asn1;
 using Xunit;
 
 namespace BricksAndHearts.UnitTests.ServiceTests.Landlord;
@@ -19,7 +18,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
     {
         Fixture = fixture;
     }
-    
+
     [Fact]
     public async void CountLandlords_ReturnsLandlordCountModel_WithCorrectData()
     {
@@ -35,7 +34,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         result.RegisteredLandlords.Should().Be(4);
         result.ApprovedLandlords.Should().Be(3);
     }
-    
+
     [Fact]
     public async void LinkExistingLandlordWithUser_WithInvalidLink_ReturnsErrorLinkDoesNotExist()
     {
@@ -47,12 +46,12 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         var nonAdminUser = new BricksAndHeartsUser(nonAdminUserModel, new List<Claim>(), "google");
 
         // Act
-        var result = await service.LinkExistingLandlordWithUser(inviteLink,nonAdminUser);
+        var result = await service.LinkExistingLandlordWithUser(inviteLink, nonAdminUser);
 
         // Assert
         result.Should().Be(ILandlordService.LinkUserWithLandlordResult.ErrorLinkDoesNotExist);
     }
-    
+
     [Fact]
     public async void LinkExistingLandlordWithUser_WithValidLink_ReturnsErrorUserAlreadyHasLandlordRecord()
     {
@@ -65,6 +64,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         {
             throw new Exception("Expect invite link to exist!");
         }
+
         var landlordUserModel = context.Users.Single(u => u.GoogleUserName == "LinkedLandlordUser");
         var user = new BricksAndHeartsUser(landlordUserModel, new List<Claim>(), "google");
 
@@ -72,19 +72,44 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         {
             throw new Exception($"Expect landlord ID to not be null!");
         }
-        
+
         if (landlordUserModel.LandlordId == landlord.Id)
         {
-            throw new Exception($"Expect landlord ID of the linked user to be different from landlord ID of unlinked landlord!");
+            throw new Exception(
+                $"Expect landlord ID of the linked user to be different from landlord ID of unlinked landlord!");
         }
-        
+
         // Act
-        var result = await service.LinkExistingLandlordWithUser(inviteLink,user);
+        var result = await service.LinkExistingLandlordWithUser(inviteLink, user);
 
         // Assert
         result.Should().Be(ILandlordService.LinkUserWithLandlordResult.ErrorUserAlreadyHasLandlordRecord);
     }
-    
+
+    [Fact]
+    public async void ApproveLandlord_SetsMembershipId()
+    {
+        // Arrange
+        await using var context = Fixture.CreateWriteContext();
+        var service = new LandlordService(context);
+
+        var landlord = context.Landlords.Single(l => l.Email == "test.landlord2@gmail.com");
+        var admin = new BricksAndHeartsUser(Fixture.CreateAdminUser(), new List<Claim>(), "google");
+
+        // Act
+        var result = await service.ApproveLandlord(landlord.Id, admin, "abc");
+
+        // Assert
+        context.ChangeTracker.Clear();
+
+        result.Should().Be($"Successfully approved landlord charter for {landlord.FirstName} {landlord.LastName}.");
+
+        landlord = context.Landlords.Single(l => l.Email == "test.landlord2@gmail.com");
+        landlord.CharterApproved.Should().BeTrue();
+        landlord.ApprovalAdminId.Should().Be(admin.Id);
+        landlord.MembershipId.Should().Be("abc");
+    }
+
     // Cannot test for the case LinkExistingLandlordWithError returning Success
     // Since it involves writing to the database and the method includes a transaction
 }

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -93,7 +93,7 @@ public class LandlordController : AbstractController
                 _logger.LogWarning("Email already registered {Email}", createModel.Email);
                 ModelState.AddModelError("Email", "Email already registered");
                 return View("Register", createModel);
-            
+
             case ILandlordService.LandlordRegistrationResult.ErrorLandlordMembershipIdAlreadyRegistered:
                 _logger.LogWarning("Membership Id already registered {MembershipId}", createModel.MembershipId);
                 ModelState.AddModelError("MembershipId", "Membership Id already registered");
@@ -144,12 +144,13 @@ public class LandlordController : AbstractController
 
     [Authorize(Roles = "Admin")]
     [HttpPost]
-    public async Task<ActionResult> ApproveCharter(int landlordId)
+    public async Task<ActionResult> ApproveCharter(LandlordProfileModel landlord)
     {
         var user = GetCurrentUser();
-        var flashMessageBody = await _landlordService.ApproveLandlord(landlordId, user);
-        FlashMessage(_logger, ("charter status updated successfully", "success", flashMessageBody));
-        return RedirectToAction("Profile", "Landlord", new { Id = landlordId });
+        var flashMessageBody =
+            await _landlordService.ApproveLandlord(landlord.LandlordId!.Value, user, landlord.MembershipId);
+        FlashMessage(_logger, ("Charter status updated successfully", "success", flashMessageBody));
+        return RedirectToAction("Profile", "Landlord", new { Id = landlord.LandlordId.Value });
     }
 
     [HttpGet]
@@ -173,7 +174,8 @@ public class LandlordController : AbstractController
         var databaseResult = _propertyService.GetPropertiesByLandlord(id.Value);
         var listOfProperties = databaseResult.Select(PropertyViewModel.FromDbModel).ToList();
         var landlordProfile = LandlordProfileModel.FromDbModel(await _landlordService.GetLandlordFromId((int)id));
-        return View("Properties", new PropertiesDashboardViewModel(listOfProperties,listOfProperties.Count, landlordProfile));
+        return View("Properties",
+            new PropertiesDashboardViewModel(listOfProperties, listOfProperties.Count, landlordProfile));
     }
 
     [HttpGet]
@@ -217,7 +219,7 @@ public class LandlordController : AbstractController
             ModelState.AddModelError("Email", "Email already registered");
             return View("EditProfilePage", editModel);
         }
-        
+
         var isMembershipIdDuplicated = _landlordService.CheckForDuplicateMembershipId(editModel);
         if (isMembershipIdDuplicated)
         {
@@ -276,7 +278,7 @@ public class LandlordController : AbstractController
 
         throw new Exception($"Unknown landlord registration error ${result}");
     }
-    
+
     [HttpGet]
     [Route("{id:int}/dashboard")]
     public async Task<ActionResult> Dashboard([FromRoute] int id)
@@ -296,7 +298,7 @@ public class LandlordController : AbstractController
         var viewModel = LandlordProfileModel.FromDbModel(landlord, user);
         return View("Dashboard", viewModel);
     }
-    
+
     [HttpGet]
     [Route("me/dashboard")]
     public async Task<ActionResult> MyDashboard()

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -103,25 +103,21 @@
             <table class="table">
                 <tr>
                     <th class="w-25">Status</th>
-                    <td>@(Model.CharterApproved ? "Approved" : "Pending")</td>
+                    <td>
+                        <div class="d-flex">
+                            @(Model.CharterApproved ? "Approved" : "Pending")
+                            @if (User.IsInRole("Admin") && !Model.CharterApproved)
+                            {
+                                <button type="button" class="btn btn-sm btn-outline-primary ms-auto" data-bs-toggle="modal" data-bs-target="#approveModal">Confirm charter membership</button>
+                            }
+                        </div>
+                    </td>
                 </tr>
                 @if (Model.MembershipId != null)
                 {
                     <tr>
                         <th>Membership ID</th>
-                        <td>
-                            <div class="d-flex">
-                                @Model.MembershipId
-                                @if (User.IsInRole("Admin") && !Model.CharterApproved)
-                                {
-                                    using (Html.BeginForm("ApproveCharter", "Landlord", null, FormMethod.Post, null, new { @class = "ms-auto" }))
-                                    {
-                                        <input type="hidden" id="landlordId" name="landlordId" value=@Model.LandlordId>
-                                        <button type="submit" class="btn btn-sm btn-outline-primary">Confirm charter membership</button>
-                                    }
-                                }
-                            </div>
-                        </td>
+                        <td>@Model.MembershipId</td>
                     </tr>
                 }
             </table>
@@ -138,3 +134,26 @@
         <button type="submit" class="btn btn-primary"><i class="bi bi-link"></i> Get invite link</button>
     }
 }
+
+<!-- Modal -->
+<div class="modal fade" id="approveModal" tabindex="-1" aria-labelledby="approveModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="approveModalLabel">Confirm charter membership for @Model.FirstName @Model.LastName</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form method="post" asp-controller="Landlord" asp-action="ApproveCharter">
+                <div class="modal-body">
+                    <label asp-for="MembershipId" class="form-label">Membership ID</label>
+                    <input type="text" asp-for="MembershipId" value="@(Model.MembershipId ?? "")" class="form-control">
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <input type="hidden" asp-for="LandlordId" value="@Model.LandlordId">
+                    <input type="submit" value="Confirm" class="btn btn-primary"/>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -149,7 +149,7 @@
                     <input type="text" asp-for="MembershipId" value="@(Model.MembershipId ?? "")" class="form-control">
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">Cancel</button>
                     <input type="hidden" asp-for="LandlordId" value="@Model.LandlordId">
                     <input type="submit" value="Confirm" class="btn btn-primary"/>
                 </div>

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -146,7 +146,7 @@
             <form method="post" asp-controller="Landlord" asp-action="ApproveCharter">
                 <div class="modal-body">
                     <label asp-for="MembershipId" class="form-label">Membership ID</label>
-                    <input type="text" asp-for="MembershipId" value="@(Model.MembershipId ?? "")" class="form-control">
+                    <input type="text" asp-for="MembershipId" value="@(Model.MembershipId ?? "")" class="form-control" required>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-outline-primary" data-bs-dismiss="modal">Cancel</button>


### PR DESCRIPTION
Admins can set/change a landlord's charter membership ID when approving them.


<img width="1367" alt="image" src="https://user-images.githubusercontent.com/41208630/183604948-5042efa3-86e2-4ab3-abfa-75c5afd08673.png">

<img width="632" alt="image" src="https://user-images.githubusercontent.com/41208630/183605005-8e27c06d-c2fb-4dcf-84e8-88e621cef716.png">

<img width="1356" alt="image" src="https://user-images.githubusercontent.com/41208630/183605067-e2c0a904-7093-4f2f-b688-27e1b5eb3f1f.png">
