### PR TITLE
BNH-120 Multiple properties per listing

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
@@ -66,7 +66,8 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         result!.ViewName.Should().Be("AddNewProperty");
         A.CallTo(() => PropertyService.GetIncompleteProperty(1)).MustHaveHappened();
         result.Model.Should().BeOfType<AddNewPropertyViewModel>().Which.Step.Should().Be(step);
-        result.Model.Should().BeOfType<AddNewPropertyViewModel>().Which.Property!.Description.Should().Be(fakePropertyDbModel.Description);
+        result.Model.Should().BeOfType<AddNewPropertyViewModel>().Which.Property!.Description.Should()
+            .Be(fakePropertyDbModel.Description);
     }
 
     [Theory]
@@ -279,37 +280,37 @@ public class PropertyControllerTests : PropertyControllerTestsBase
     {
         // Arrange
         A.CallTo(() => PropertyService.GetPropertyByPropertyId(1)).Returns(null);
-        
+
         var landlordUser = CreateLandlordUser();
         MakeUserPrincipalInController(landlordUser, UnderTest);
-        
+
         // Act
         var result = UnderTest.ViewProperty(1);
-        
+
         // Assert
         A.CallTo(() => PropertyService.GetPropertyByPropertyId(1)).MustHaveHappened();
         result.Should().BeOfType<RedirectToActionResult>().Which.ActionName.Should().Be("Error");
-        result.As<RedirectToActionResult>().RouteValues.Should().Contain("status",404);
+        result.As<RedirectToActionResult>().RouteValues.Should().Contain("status", 404);
     }
-    
+
     [Fact]
     public void ViewProperty_WithExistingProperty_ReturnViewPropertyView()
     {
         // Arrange
         var model = CreateExamplePropertyDbModel();
         A.CallTo(() => PropertyService.GetPropertyByPropertyId(1)).Returns(model);
-        
+
         var landlordUser = CreateLandlordUser();
         MakeUserPrincipalInController(landlordUser, UnderTest);
-        
+
         // Act
         var result = UnderTest.ViewProperty(1) as ViewResult;
-        
+
         // Assert
         A.CallTo(() => PropertyService.GetPropertyByPropertyId(1)).MustHaveHappened();
         result!.ViewData.Model.Should().BeOfType<PropertyViewModel>();
     }
-    
+
     // This is not working
     /*[Fact]
     public async void ListPropertyImages_CallsListFilesAsync_AndReturnsViewListPropertyImages()
@@ -338,7 +339,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         A.CallTo(() => AzureStorage.ListFileNames("property", 1)).MustHaveHappened();
         result!.ViewData.Model.Should().BeOfType<ImageListViewModel>().And.Be(fileNames);
     }*/
-    
+
     [Fact]
     public async void AddPropertyImages_CallsUploadImageForEachImage_AndRedirectsToListImagesWithFlashMultipleMessages()
     {
@@ -351,8 +352,8 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         var fakeImage2 = CreateExampleImage();
         A.CallTo(() => AzureStorage.IsImage(fakeImage.FileName)).Returns((true, null));
         A.CallTo(() => AzureStorage.IsImage(fakeImage2.FileName)).Returns((true, null));
-        var fakeImageList = new List<IFormFile>{fakeImage, fakeImage2};
-        
+        var fakeImageList = new List<IFormFile> { fakeImage, fakeImage2 };
+
         // Act
         var result = await UnderTest.AddPropertyImages(fakeImageList, 1);
 
@@ -369,7 +370,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         var adminUser = CreateAdminUser();
         MakeUserPrincipalInController(adminUser, UnderTest);
         A.CallTo(() => PropertyService.IsUserAdminOrCorrectLandlord(adminUser, 1)).Returns(true);
-        
+
         var fakeImage = CreateExampleImage();
         var image = (fakeImage.OpenReadStream(), "jpeg");
         A.CallTo(() => AzureStorage.DownloadFile("property", 1, fakeImage.FileName)).Returns(image);
@@ -381,7 +382,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         A.CallTo(() => AzureStorage.DownloadFile("property", 1, fakeImage.FileName)).MustHaveHappened();
         result!.ContentType.Should().Be("image/jpeg");
     }
-    
+
     [Fact]
     public async void DeleteImage_CallsDeleteFileAsync_AndRedirectsToListImages()
     {
@@ -389,9 +390,9 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         var adminUser = CreateAdminUser();
         MakeUserPrincipalInController(adminUser, UnderTest);
         A.CallTo(() => PropertyService.IsUserAdminOrCorrectLandlord(adminUser, 1)).Returns(true);
-        
+
         var fakeImage = CreateExampleImage();
-        
+
         // Act
         var result = await UnderTest.DeletePropertyImage(1, fakeImage.FileName);
 
@@ -399,7 +400,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         A.CallTo(() => AzureStorage.DeleteFile("property", 1, fakeImage.FileName)).MustHaveHappened();
         result.Should().BeOfType<RedirectToActionResult>().Which.ActionName.Should().Be("ListPropertyImages");
     }
-    
+
     [Fact]
     public void DeleteProperty_WithExistingProperty_DeletesAndRedirectsToViewProperties()
     {
@@ -417,7 +418,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         A.CallTo(() => PropertyService.DeleteProperty(fakePropertyDbModel)).MustHaveHappened();
         result.Should().BeOfType<RedirectToActionResult>().Which.ActionName.Should().Be("ViewProperties");
     }
-    
+
     [Fact]
     public void DeleteProperty_WithNonExistingProperty_Returns404ErrorPage()
     {
@@ -436,7 +437,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         A.CallTo(() => PropertyService.DeleteProperty(fakePropertyDbModel)).MustNotHaveHappened();
         result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(404);
     }
-    
+
     [Fact]
     public void SortProperties_ReturnsViewWith_PropertiesDashboardViewModel()
     {
@@ -448,5 +449,18 @@ public class PropertyControllerTests : PropertyControllerTestsBase
 
         // Assert
         result!.ViewData.Model.Should().BeOfType<PropertiesDashboardViewModel>();
+    }
+
+    [Fact]
+    public void AvailableUnits_CalculatesCorrectly()
+    {
+        // Arrange
+        var property = CreateExamplePropertyViewModel();
+
+        // Act
+        var availableUnits = property.AvailableUnits;
+
+        // Assert
+        availableUnits.Should().Be(3);
     }
 }

--- a/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTestsBase.cs
@@ -27,7 +27,8 @@ public class PropertyControllerTestsBase : ControllerTestsBase
         Logger = A.Fake<ILogger<PropertyController>>();
         var httpContext = new DefaultHttpContext();
         var tempData = new TempDataDictionary(httpContext, A.Fake<ITempDataProvider>());
-        UnderTest = new PropertyController(PropertyService, AzureMapsApiService, Logger, AzureStorage){TempData = tempData};
+        UnderTest = new PropertyController(PropertyService, AzureMapsApiService, Logger, AzureStorage)
+            { TempData = tempData };
     }
 
     protected PropertyViewModel CreateExamplePropertyViewModel()
@@ -47,7 +48,9 @@ public class PropertyControllerTestsBase : ControllerTestsBase
             NumOfBedrooms = 2,
             Rent = 1200,
             Description = "Description",
-            CreationTime = DateTime.Now
+            CreationTime = DateTime.Now,
+            TotalUnits = 5,
+            OccupiedUnits = 2
         };
     }
 

--- a/BricksAndHearts.UnitTests/ServiceTests/Property/PropertyServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Property/PropertyServiceTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using BricksAndHearts.Database;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using FluentAssertions;
@@ -147,9 +146,9 @@ public class PropertyServiceTests : PropertyServiceTestsBase
         var registeredCount = context.Properties.Count();
         result.RegisteredProperties.Should().Be(registeredCount);
         var liveCount =
-            context.Properties.Count(p => p.Availability != PropertyDbModel.Avail_Draft && p.Landlord.CharterApproved);
+            context.Properties.Count(p => p.Availability != AvailabilityState.Draft && p.Landlord.CharterApproved);
         result.LiveProperties.Should().Be(liveCount);
-        var availableCount = context.Properties.Count(p => p.Availability == PropertyDbModel.Avail_Available);
+        var availableCount = context.Properties.Count(p => p.Availability == AvailabilityState.Available);
         result.AvailableProperties.Should().Be(availableCount);
     }
 

--- a/BricksAndHearts.UnitTests/ServiceTests/Property/PropertyServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Property/PropertyServiceTests.cs
@@ -1,7 +1,10 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace BricksAndHearts.UnitTests.ServiceTests.Property;
@@ -103,6 +106,120 @@ public class PropertyServiceTests : PropertyServiceTestsBase
         property.IsIncomplete.Should().BeFalse();
         property.AcceptsBenefits.Should().BeFalse();
         context.Properties.Count().Should().Be(propertiesBeforeCount);
+    }
+
+    [Fact]
+    public void UpdateProperty_SetsStateToOccupied_IfAllUnitsOccupied()
+    {
+        // Arrange
+        using var context = Fixture.CreateWriteContext();
+        var service = new PropertyService(context);
+
+        var propertyDb = context.Properties.Single(p => p.AddressLine1 == "MultiUnit Property");
+        var propertyUpdate = new PropertyViewModel { OccupiedUnits = propertyDb.TotalUnits };
+
+        // Act
+        service.UpdateProperty(propertyDb.Id, propertyUpdate, isIncomplete: false);
+        context.ChangeTracker.Clear();
+
+        // Assert
+        propertyDb = context.Properties.Single(p => p.AddressLine1 == "MultiUnit Property");
+        propertyDb.Availability.Should().Be(AvailabilityState.Occupied);
+        propertyDb.OccupiedUnits.Should().Be(propertyDb.TotalUnits);
+    }
+
+    [Fact]
+    public void UpdateProperty_Fails_OccupiedGreaterThanTotal()
+    {
+        // Arrange
+        using var context = Fixture.CreateWriteContext();
+        var service = new PropertyService(context);
+
+        var propertyDb = context.Properties.Single(p => p.AddressLine1 == "MultiUnit Property");
+        var propertyUpdate = new PropertyViewModel { OccupiedUnits = propertyDb.TotalUnits + 1 };
+
+        // Act
+        var act = () => service.UpdateProperty(propertyDb.Id, propertyUpdate, isIncomplete: false);
+        context.ChangeTracker.Clear();
+
+        // Assert
+        act.Should().Throw<DbUpdateException>().WithInnerException<SqlException>()
+            .WithMessage("The UPDATE statement conflicted with the CHECK constraint \"OccupiedUnits\".*");
+    }
+
+    [Fact]
+    public void UpdateProperty_UpdatesAvailableFromDate_WhenAvailableSoon()
+    {
+        // Arrange
+        using var context = Fixture.CreateWriteContext();
+        var service = new PropertyService(context);
+
+        var date = DateTime.Now;
+        var propertyDb = context.Properties.Single(p => p.AddressLine1 == "MultiUnit Property");
+        var propertyUpdate = new PropertyViewModel
+        {
+            Availability = AvailabilityState.AvailableSoon,
+            AvailableFrom = date
+        };
+
+        // Act
+        service.UpdateProperty(propertyDb.Id, propertyUpdate, isIncomplete: false);
+        context.ChangeTracker.Clear();
+
+        // Assert
+        propertyDb = context.Properties.Single(p => p.AddressLine1 == "MultiUnit Property");
+        propertyDb.Availability.Should().Be(AvailabilityState.AvailableSoon);
+        propertyDb.AvailableFrom.Should().Be(date);
+    }
+
+    [Fact]
+    public void UpdateProperty_DoesntChangeAvailableFromDate_WhenOccupiedStateOverrides()
+    {
+        // Arrange
+        using var context = Fixture.CreateWriteContext();
+        var service = new PropertyService(context);
+
+        var date = DateTime.Now;
+        var propertyDb = context.Properties.Single(p => p.AddressLine1 == "AvailableSoon Property");
+        var propertyUpdate = new PropertyViewModel
+        {
+            AvailableFrom = date
+        };
+
+        // Act
+        service.UpdateProperty(propertyDb.Id, propertyUpdate, isIncomplete: false);
+        context.ChangeTracker.Clear();
+
+        // Assert
+        propertyDb = context.Properties.Single(p => p.AddressLine1 == "AvailableSoon Property");
+        propertyDb.Availability.Should().Be(AvailabilityState.AvailableSoon);
+        propertyDb.AvailableFrom.Should().NotBe(date).And.Be(DateTime.MinValue);
+    }
+
+    [Fact]
+    public void UpdateProperty_SetsAvailableFromDateToNull_WhenOccupiedStateOverrides()
+    {
+        // Arrange
+        using var context = Fixture.CreateWriteContext();
+        var service = new PropertyService(context);
+
+        var date = DateTime.Now;
+        var propertyDb = context.Properties.Single(p => p.AddressLine1 == "MultiUnit Property");
+        var propertyUpdate = new PropertyViewModel
+        {
+            OccupiedUnits = propertyDb.TotalUnits,
+            Availability = AvailabilityState.AvailableSoon,
+            AvailableFrom = date
+        };
+
+        // Act
+        service.UpdateProperty(propertyDb.Id, propertyUpdate, isIncomplete: false);
+        context.ChangeTracker.Clear();
+
+        // Assert
+        propertyDb = context.Properties.Single(p => p.AddressLine1 == "MultiUnit Property");
+        propertyDb.Availability.Should().Be(AvailabilityState.Occupied);
+        propertyDb.AvailableFrom.Should().BeNull();
     }
 
     #endregion

--- a/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
@@ -1,4 +1,5 @@
 ﻿using BricksAndHearts.Database;
+using BricksAndHearts.ViewModels;
 using Microsoft.Extensions.Configuration;
 
 namespace BricksAndHearts.UnitTests.ServiceTests;
@@ -249,7 +250,7 @@ public class TestDatabaseFixture
             TownOrCity = "Complete Town",
             County = "Complete County",
             Postcode = "CB2 1LA",
-            Availability = PropertyDbModel.Avail_Occupied
+            Availability = AvailabilityState.Occupied
         };
     }
 
@@ -264,10 +265,10 @@ public class TestDatabaseFixture
             TownOrCity = "Incomplete Town",
             County = "Incomplete County",
             Postcode = "CB2 1LA",
-            Availability = PropertyDbModel.Avail_Occupied
+            Availability = AvailabilityState.Occupied
         };
     }
-    
+
     private PropertyDbModel CreateAvailableProperty()
     {
         return new PropertyDbModel
@@ -279,10 +280,10 @@ public class TestDatabaseFixture
             TownOrCity = "Available Town",
             County = "Available County",
             Postcode = "CB2 1LA",
-            Availability = PropertyDbModel.Avail_Available
+            Availability = AvailabilityState.Available
         };
     }
-    
+
     private PropertyDbModel CreateDraftProperty()
     {
         return new PropertyDbModel
@@ -294,7 +295,7 @@ public class TestDatabaseFixture
             TownOrCity = "Draft Town",
             County = "Draft County",
             Postcode = "CB2 1LA",
-            Availability = PropertyDbModel.Avail_Draft
+            Availability = AvailabilityState.Draft
         };
     }
 

--- a/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
@@ -1,4 +1,5 @@
-﻿using BricksAndHearts.Database;
+﻿using System;
+using BricksAndHearts.Database;
 using BricksAndHearts.ViewModels;
 using Microsoft.Extensions.Configuration;
 
@@ -51,7 +52,9 @@ public class TestDatabaseFixture
                     CreateCompleteProperty(),
                     CreateIncompleteProperty(),
                     CreateAvailableProperty(),
-                    CreateDraftProperty()
+                    CreateDraftProperty(),
+                    CreateMultiUnitProperty(),
+                    CreateAvailableSoonProperty()
                 );
 
                 context.Tenants.AddRange(
@@ -250,7 +253,9 @@ public class TestDatabaseFixture
             TownOrCity = "Complete Town",
             County = "Complete County",
             Postcode = "CB2 1LA",
-            Availability = AvailabilityState.Occupied
+            Availability = AvailabilityState.Occupied,
+            TotalUnits = 1,
+            OccupiedUnits = 1
         };
     }
 
@@ -265,7 +270,7 @@ public class TestDatabaseFixture
             TownOrCity = "Incomplete Town",
             County = "Incomplete County",
             Postcode = "CB2 1LA",
-            Availability = AvailabilityState.Occupied
+            Availability = AvailabilityState.Draft
         };
     }
 
@@ -281,6 +286,39 @@ public class TestDatabaseFixture
             County = "Available County",
             Postcode = "CB2 1LA",
             Availability = AvailabilityState.Available
+        };
+    }
+
+    private PropertyDbModel CreateAvailableSoonProperty()
+    {
+        return new PropertyDbModel
+        {
+            LandlordId = 1,
+            IsIncomplete = true,
+            AddressLine1 = "AvailableSoon Property",
+            AddressLine2 = "Available Street",
+            TownOrCity = "Available Town",
+            County = "Available County",
+            Postcode = "CB2 1LA",
+            Availability = AvailabilityState.AvailableSoon,
+            AvailableFrom = DateTime.MinValue
+        };
+    }
+
+    private PropertyDbModel CreateMultiUnitProperty()
+    {
+        return new PropertyDbModel
+        {
+            LandlordId = 1,
+            IsIncomplete = true,
+            AddressLine1 = "MultiUnit Property",
+            AddressLine2 = "Available Street",
+            TownOrCity = "Available Town",
+            County = "Available County",
+            Postcode = "CB2 1LA",
+            Availability = AvailabilityState.Available,
+            TotalUnits = 5,
+            OccupiedUnits = 0
         };
     }
 

--- a/web/Database/BricksAndHeartsDbContext.cs
+++ b/web/Database/BricksAndHeartsDbContext.cs
@@ -19,7 +19,7 @@ public class BricksAndHeartsDbContext : DbContext
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.UseSqlServer(_config.GetValue<string>("DBConnectionString"));
-        optionsBuilder.LogTo(Console.WriteLine, minimumLevel: LogLevel.Information);
+        optionsBuilder.LogTo(Console.WriteLine, LogLevel.Information);
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -44,6 +44,8 @@ public class BricksAndHeartsDbContext : DbContext
         modelBuilder.Entity<PropertyDbModel>()
             .Property(l => l.Lon)
             .HasPrecision(12, 9);
+        modelBuilder.Entity<PropertyDbModel>()
+            .HasCheckConstraint("OccupiedUnits", "[OccupiedUnits] <= [TotalUnits]");
     }
 
     public static void MigrateDatabase(WebApplication app)

--- a/web/Database/PropertyDbModel.cs
+++ b/web/Database/PropertyDbModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using BricksAndHearts.ViewModels;
 
 namespace BricksAndHearts.Database;
 
@@ -42,14 +43,12 @@ public class PropertyDbModel
     // Rent, deposits, availability and duration
     public int? Rent { get; set; }
 
-    public string Availability { get; set; } = Avail_Draft;
-    public const string Avail_Draft = "Draft";
-    public const string Avail_Available = "Available";
-    public const string Avail_AvailableSoon = "Available Soon";
-    public const string Avail_Occupied = "Occupied";
-    public const string Avail_Unavailable = "Unavailable";
-    
+    // Availability
+    public string Availability { get; set; } = AvailabilityState.Draft;
+
     [DataType(DataType.Date)]
     public DateTime? AvailableFrom { get; set; } = null;
+
+    // Tenant
     public int? RenterUserId { get; set; } = null;
 }

--- a/web/Database/PropertyDbModel.cs
+++ b/web/Database/PropertyDbModel.cs
@@ -43,8 +43,10 @@ public class PropertyDbModel
     // Rent, deposits, availability and duration
     public int? Rent { get; set; }
 
-    // Availability
+    // Availability and units
     public string Availability { get; set; } = AvailabilityState.Draft;
+    public int TotalUnits { get; set; } = 1;
+    public int OccupiedUnits { get; set; }
 
     [DataType(DataType.Date)]
     public DateTime? AvailableFrom { get; set; } = null;

--- a/web/Migrations/20220809110124_AddMultipleUnitsToAProperty.Designer.cs
+++ b/web/Migrations/20220809110124_AddMultipleUnitsToAProperty.Designer.cs
@@ -4,6 +4,7 @@ using BricksAndHearts.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BricksAndHearts.Migrations
 {
     [DbContext(typeof(BricksAndHeartsDbContext))]
-    partial class BricksAndHeartsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220809110124_AddMultipleUnitsToAProperty")]
+    partial class AddMultipleUnitsToAProperty
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/web/Migrations/20220809110124_AddMultipleUnitsToAProperty.cs
+++ b/web/Migrations/20220809110124_AddMultipleUnitsToAProperty.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BricksAndHearts.Migrations
+{
+    public partial class AddMultipleUnitsToAProperty : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "OccupiedUnits",
+                table: "Property",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TotalUnits",
+                table: "Property",
+                type: "int",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "OccupiedUnits",
+                table: "Property",
+                sql: "[OccupiedUnits] <= [TotalUnits]");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "OccupiedUnits",
+                table: "Property");
+
+            migrationBuilder.DropColumn(
+                name: "OccupiedUnits",
+                table: "Property");
+
+            migrationBuilder.DropColumn(
+                name: "TotalUnits",
+                table: "Property");
+        }
+    }
+}

--- a/web/Services/PropertyService.cs
+++ b/web/Services/PropertyService.cs
@@ -129,11 +129,6 @@ public class PropertyService : IPropertyService
                 // If update succeeds in making the property "available soon", then use its from date
                 dbModel.AvailableFrom = updateModel.AvailableFrom;
             }
-            else
-            {
-                // Keep date the same if we're not updating it here
-                dbModel.AvailableFrom = dbModel.AvailableFrom;
-            }
         }
         else
         {

--- a/web/Services/PropertyService.cs
+++ b/web/Services/PropertyService.cs
@@ -66,7 +66,7 @@ public class PropertyService : IPropertyService
 
             Rent = createModel.Rent,
 
-            Availability = createModel.Availability,
+            Availability = createModel.Availability ?? AvailabilityState.Draft,
             TotalUnits = createModel.TotalUnits ?? 1,
             OccupiedUnits = createModel.OccupiedUnits ?? 0
         };

--- a/web/Services/PropertyService.cs
+++ b/web/Services/PropertyService.cs
@@ -67,14 +67,10 @@ public class PropertyService : IPropertyService
             Rent = createModel.Rent,
             Availability = createModel.Availability,
         };
-        if (createModel.Availability == PropertyDbModel.Avail_AvailableSoon)
-        {
-            dbModel.AvailableFrom = createModel.AvailableFrom;
-        }
-        else
-        {
-            dbModel.AvailableFrom = null;
-        }
+
+        dbModel.AvailableFrom = createModel.Availability == AvailabilityState.AvailableSoon
+            ? createModel.AvailableFrom
+            : null;
 
         // Add the new property to the database
         _dbContext.Properties.Add(dbModel);
@@ -114,14 +110,10 @@ public class PropertyService : IPropertyService
 
         dbModel.Rent = updateModel.Rent ?? dbModel.Rent;
         dbModel.Availability = updateModel.Availability;
-        if (updateModel.Availability == PropertyDbModel.Avail_AvailableSoon)
-        {
-            dbModel.AvailableFrom = updateModel.AvailableFrom;
-        }
-        else
-        {
-            dbModel.AvailableFrom = null;
-        }
+
+        dbModel.AvailableFrom = updateModel.Availability == AvailabilityState.AvailableSoon
+            ? updateModel.AvailableFrom
+            : null;
 
         dbModel.IsIncomplete = isIncomplete;
         _dbContext.SaveChanges();
@@ -155,7 +147,7 @@ public class PropertyService : IPropertyService
         var userLandlordId = currentUser.LandlordId;
         return propertyLandlordId == userLandlordId;
     }
-    
+
     public List<PropertyDbModel> SortProperties(string? by)
     {
         List<PropertyDbModel> properties;
@@ -165,18 +157,23 @@ public class PropertyService : IPropertyService
         }
         else if (by == "Rent")
             properties = _dbContext.Properties.OrderBy(m => m.Rent).ToList();
-        else {
+        else
+        {
             properties = _dbContext.Properties.ToList();
         }
+
         return properties;
     }
-    
+
     public PropertyCountModel CountProperties()
     {
-        PropertyCountModel propertyCounts = new PropertyCountModel();
-        propertyCounts.RegisteredProperties = _dbContext.Properties.Count();
-        propertyCounts.LiveProperties = _dbContext.Properties.Count(p => p.Availability != PropertyDbModel.Avail_Draft && p.Landlord.CharterApproved);
-        propertyCounts.AvailableProperties = _dbContext.Properties.Count(p => p.Availability == PropertyDbModel.Avail_Available);
+        var propertyCounts = new PropertyCountModel
+        {
+            RegisteredProperties = _dbContext.Properties.Count(),
+            LiveProperties = _dbContext.Properties.Count(p =>
+                p.Availability != AvailabilityState.Draft && p.Landlord.CharterApproved),
+            AvailableProperties = _dbContext.Properties.Count(p => p.Availability == AvailabilityState.Available)
+        };
         return propertyCounts;
     }
 }

--- a/web/ViewModels/AvailabilityState.cs
+++ b/web/ViewModels/AvailabilityState.cs
@@ -1,0 +1,10 @@
+﻿namespace BricksAndHearts.ViewModels;
+
+public static class AvailabilityState
+{
+    public const string Draft = "Draft";
+    public const string Available = "Available";
+    public const string AvailableSoon = "Available soon";
+    public const string Occupied = "Occupied";
+    public const string Unavailable = "Unavailable";
+}

--- a/web/ViewModels/PropertyViewModel.cs
+++ b/web/ViewModels/PropertyViewModel.cs
@@ -23,7 +23,7 @@ public class PropertyViewModel : IValidatableObject
     public string? PropertyType { get; set; }
 
     [Range(0, 1000, ErrorMessage = "Value for {0} must be between {1} and {2}.")]
-    [DisplayName("Number of Bedrooms")]
+    [DisplayName("Number of bedrooms")]
     public int? NumOfBedrooms { get; set; }
 
 
@@ -47,15 +47,41 @@ public class PropertyViewModel : IValidatableObject
     public int? Rent { get; set; }
 
 
-    // Availability
-    public string Availability { get; set; } = AvailabilityState.Draft;
+    // Availability and units
+    public string? Availability { get; set; } = AvailabilityState.Draft;
 
     [DataType(DataType.Date)]
     public DateTime? AvailableFrom { get; set; }
 
+    [Range(1, 10000, ErrorMessage = "Total units for a property must be between {1} and {2}.")]
+    public int? TotalUnits { get; set; } = 1;
+
+    public int? OccupiedUnits { get; set; }
+
 
     // Tenant
     public int? UserWhoRented { get; set; }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (AcceptsSingleTenant == false && AcceptsCouple == false && AcceptsFamily == false)
+        {
+            yield return new ValidationResult("At least one type of tenant must be selected");
+        }
+
+        if (Availability == AvailabilityState.AvailableSoon && AvailableFrom == null)
+        {
+            yield return new ValidationResult("Available From must be provided if property is Available Soon");
+        }
+
+        if (OccupiedUnits > TotalUnits)
+        {
+            yield return new ValidationResult(
+                "The number of occupied units must be less than or equal to the total units at the property.");
+        }
+    }
+
+    public int? AvailableUnits => TotalUnits - OccupiedUnits;
 
 
     public static PropertyViewModel FromDbModel(PropertyDbModel property)
@@ -78,7 +104,7 @@ public class PropertyViewModel : IValidatableObject
                 AddressLine3 = property.AddressLine3,
                 TownOrCity = property.TownOrCity,
                 County = property.County,
-                Postcode = property.Postcode,
+                Postcode = property.Postcode
             },
             AcceptsSingleTenant = property.AcceptsSingleTenant,
             AcceptsCouple = property.AcceptsCouple,
@@ -89,21 +115,10 @@ public class PropertyViewModel : IValidatableObject
             AcceptsWithoutGuarantor = property.AcceptsWithoutGuarantor,
             Availability = property.Availability,
             AvailableFrom = property.AvailableFrom,
-            UserWhoRented = property.RenterUserId
+            UserWhoRented = property.RenterUserId,
+            TotalUnits = property.TotalUnits,
+            OccupiedUnits = property.OccupiedUnits
         };
-    }
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (AcceptsSingleTenant == false && AcceptsCouple == false && AcceptsFamily == false)
-        {
-            yield return new ValidationResult("At least one type of tenant must be selected");
-        }
-
-        if (Availability == AvailabilityState.AvailableSoon && AvailableFrom == null)
-        {
-            yield return new ValidationResult("Available From must be provided if property is Available Soon");
-        }
     }
 }
 

--- a/web/ViewModels/PropertyViewModel.cs
+++ b/web/ViewModels/PropertyViewModel.cs
@@ -48,13 +48,13 @@ public class PropertyViewModel : IValidatableObject
 
 
     // Availability and units
-    public string? Availability { get; set; } = AvailabilityState.Draft;
+    public string? Availability { get; set; }
 
     [DataType(DataType.Date)]
     public DateTime? AvailableFrom { get; set; }
 
     [Range(1, 10000, ErrorMessage = "Total units for a property must be between {1} and {2}.")]
-    public int? TotalUnits { get; set; } = 1;
+    public int? TotalUnits { get; set; }
 
     public int? OccupiedUnits { get; set; }
 

--- a/web/ViewModels/PropertyViewModel.cs
+++ b/web/ViewModels/PropertyViewModel.cs
@@ -8,12 +8,14 @@ public class PropertyViewModel : IValidatableObject
 {
     // Backend info
     public int PropertyId;
+    public int LandlordId { get; set; }
     public DateTime? CreationTime { get; set; }
 
 
-    // Address
-    public int LandlordId { get; set; }
+    // Location
     public PropertyAddress Address { get; set; } = new();
+    public decimal? Lat { get; set; }
+    public decimal? Lon { get; set; }
 
 
     // Property details
@@ -38,19 +40,22 @@ public class PropertyViewModel : IValidatableObject
     public bool? AcceptsBenefits { get; set; }
     public bool? AcceptsNotEET { get; set; }
     public bool? AcceptsWithoutGuarantor { get; set; }
-    
+
+
     // Rent, deposits, and duration
     [Range(0, 100000, ErrorMessage = "Value for {0} must be between {1} and {2}.")]
     public int? Rent { get; set; }
-    public string Availability { get; set; } = PropertyDbModel.Avail_Draft;
-    
+
+
+    // Availability
+    public string Availability { get; set; } = AvailabilityState.Draft;
+
     [DataType(DataType.Date)]
     public DateTime? AvailableFrom { get; set; }
+
+
+    // Tenant
     public int? UserWhoRented { get; set; }
-    
-    // Latitude and Longitude
-    public decimal? Lat { get; set; }
-    public decimal? Lon { get; set; }
 
 
     public static PropertyViewModel FromDbModel(PropertyDbModel property)
@@ -95,11 +100,10 @@ public class PropertyViewModel : IValidatableObject
             yield return new ValidationResult("At least one type of tenant must be selected");
         }
 
-        if (Availability == PropertyDbModel.Avail_AvailableSoon && AvailableFrom == null)
+        if (Availability == AvailabilityState.AvailableSoon && AvailableFrom == null)
         {
             yield return new ValidationResult("Available From must be provided if property is Available Soon");
         }
-        
     }
 }
 

--- a/web/Views/Landlord/Properties.cshtml
+++ b/web/Views/Landlord/Properties.cshtml
@@ -21,11 +21,14 @@ else
         <th scope="col">#</th>
         <th scope="col">Address</th>
         <th scope="col">Type</th>
-        <th scope="col"># of Bedrooms</th>
+        <th scope="col">Bedrooms</th>
         <th scope="col">Created</th>
         <th scope="col">Rent (pcm)</th>
         <th scope="col">Availability</th>
         <th scope="col">Description</th>
+        <th scope="col">Total units</th>
+        <th scope="col">Occupied units</th>
+        <th scope="col">Available units</th>
         <th scope="col"></th>
     </tr>
     </thead>
@@ -52,6 +55,9 @@ else
             <td>@prop.Rent</td>
             <td>@prop.Availability</td>
             <td>@prop.Description</td>
+            <td>@prop.TotalUnits</td>
+            <td>@prop.OccupiedUnits</td>
+            <td>@prop.AvailableUnits</td>
             <td>@Html.ActionLink("View", "ViewProperty", "Property", new { propertyId = prop.PropertyId })</td>
         </tr>
         i++;

--- a/web/Views/Property/ViewProperty.cshtml
+++ b/web/Views/Property/ViewProperty.cshtml
@@ -1,5 +1,4 @@
-﻿@using BricksAndHearts.Database
-@using Microsoft.AspNetCore.Mvc.TagHelpers
+﻿@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model PropertyViewModel
 
 @{
@@ -14,7 +13,7 @@
         <div class="col-7 border p-2">
             <p>@Model.Address.AddressLine1</p>
             <p>Avaibility status: @Model.Availability</p>
-            @if (Model.Availability == PropertyDbModel.Avail_AvailableSoon)
+            @if (Model.Availability == AvailabilityState.AvailableSoon)
             {
                 <p>Available from: @Model.AvailableFrom!.Value.ToString("dd/MM/yyyy")</p>
             }
@@ -87,7 +86,7 @@
             </table>
         </div>
     </div>
-    @Html.ActionLink("Property images", "ListPropertyImages", "Property", new { propertyId = Model.PropertyId }, 
+    @Html.ActionLink("Property images", "ListPropertyImages", "Property", new { propertyId = Model.PropertyId },
         new { @class = "btn btn-primary" })
     <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#deleteModal">
         Delete Property

--- a/web/Views/Property/ViewProperty.cshtml
+++ b/web/Views/Property/ViewProperty.cshtml
@@ -17,6 +17,9 @@
             {
                 <p>Available from: @Model.AvailableFrom!.Value.ToString("dd/MM/yyyy")</p>
             }
+            <p>Total units: @Model.TotalUnits</p>
+            <p>Occupied units: @Model.OccupiedUnits</p>
+            <p>Available units: @Model.AvailableUnits</p>
         </div>
     </div>
     <div class="row mb-3">

--- a/web/Views/Property/_AddFormStep6.cshtml
+++ b/web/Views/Property/_AddFormStep6.cshtml
@@ -1,4 +1,3 @@
-@using BricksAndHearts.Database
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @model PropertyViewModel
 
@@ -18,17 +17,17 @@
 <div class="my-4 py-3">
     <label asp-for="Availability" class="form-label">Availability</label>
     <select asp-for="Availability" class="form-select" required
-            id="Select" onclick="checkIfSelectedValueIsTarget('Available Soon')">
-        <option selected>@PropertyDbModel.Avail_Draft</option>
-        <option>@PropertyDbModel.Avail_Available</option>
-        <option>@PropertyDbModel.Avail_AvailableSoon</option>
-        <option>@PropertyDbModel.Avail_Occupied</option>
-        <option>@PropertyDbModel.Avail_Unavailable</option>
+            id="Select" onclick="checkIfSelectedValueIsTarget('@AvailabilityState.AvailableSoon')">
+        <option selected>@AvailabilityState.Draft</option>
+        <option>@AvailabilityState.Available</option>
+        <option>@AvailabilityState.AvailableSoon</option>
+        <option>@AvailabilityState.Occupied</option>
+        <option>@AvailabilityState.Unavailable</option>
     </select>
     <span asp-validation-for="Availability" class="text-danger"></span>
 </div>
 
-<div id="ifTrue" class="form-group my-3" style="@(Model.Availability == "Available Soon" ? "" : "display: none;")">
+<div id="ifTrue" class="form-group my-3" style="@(Model.Availability == AvailabilityState.AvailableSoon ? "" : "display: none;")">
     <label asp-for="AvailableFrom" class="form-label">Available from</label>
     <input asp-for="AvailableFrom" class="form-control empty"/>
     <span asp-validation-for="AvailableFrom" class="text-danger"></span>

--- a/web/Views/Property/_AddFormStep6.cshtml
+++ b/web/Views/Property/_AddFormStep6.cshtml
@@ -14,24 +14,27 @@
     <span asp-validation-for="Rent" class="text-danger"></span>
 </div>
 
-<div class="my-4 py-3">
-    <label asp-for="Availability" class="form-label">Availability</label>
-    <select asp-for="Availability" class="form-select" required
-            id="Select" onclick="checkIfSelectedValueIsTarget('@AvailabilityState.AvailableSoon')">
-        <option selected>@AvailabilityState.Draft</option>
-        <option>@AvailabilityState.Available</option>
-        <option>@AvailabilityState.AvailableSoon</option>
-        <option>@AvailabilityState.Occupied</option>
-        <option>@AvailabilityState.Unavailable</option>
-    </select>
-    <span asp-validation-for="Availability" class="text-danger"></span>
+<div class="my-4 py-3 row">
+    <div class="col-auto">
+        <label asp-for="Availability" class="form-label">Availability</label>
+        <select asp-for="Availability" class="form-select" required
+                id="availabilitySelect" onclick="checkIfSelectedValueIsTarget('@AvailabilityState.AvailableSoon')">
+            <option selected>@AvailabilityState.Draft</option>
+            <option>@AvailabilityState.Available</option>
+            <option>@AvailabilityState.AvailableSoon</option>
+            <option>@AvailabilityState.Unavailable</option>
+        </select>
+        <span asp-validation-for="Availability" class="text-danger"></span>
+    </div>
+    <div class="col-auto" id="availableFromInput" style="@(Model.Availability == AvailabilityState.AvailableSoon ? "" : "display: none;")">
+        <label asp-for="AvailableFrom" class="form-label">Available from</label>
+        <input asp-for="AvailableFrom" class="form-control empty"/>
+        <span asp-validation-for="AvailableFrom" class="text-danger"></span>
+        @*TODO require AvailableFrom date to be in future*@
+    </div>
 </div>
 
-<div id="ifTrue" class="form-group my-3" style="@(Model.Availability == AvailabilityState.AvailableSoon ? "" : "display: none;")">
-    <label asp-for="AvailableFrom" class="form-label">Available from</label>
-    <input asp-for="AvailableFrom" class="form-control empty"/>
-    <span asp-validation-for="AvailableFrom" class="text-danger"></span>
-    @*TODO require AvailableFrom date to be in future*@
-</div>
-<div id="ifFalse" style="@(Model.Availability != "AvailableSoon" ? "" : "display: none;")">
+<div class="my-4 py-3">
+    <label asp-for="TotalUnits" class="form-label">Number of units available in this property</label>
+    <input asp-for="TotalUnits" class="form-control" required>
 </div>

--- a/web/wwwroot/js/site.js
+++ b/web/wwwroot/js/site.js
@@ -8,15 +8,10 @@ function setValue(elementId, value) {
 }
 
 function checkIfSelectedValueIsTarget(target){
-    if ($("#Select :selected").val() == target)
-    {
-        $("#ifTrue").show();
-        $("#ifFalse").hide();
-    }
-    else
-    {
-        $("#ifTrue").hide();
-        $("#ifFalse").show();
+    if ($("#availabilitySelect :selected").val() == target) {
+        $("#availableFromInput").show();
+    } else {
+        $("#availableFromInput").hide();
     }
 }
 


### PR DESCRIPTION
- Added `TotalUnits` and `OccupiedUnits` to Property table to track how many properties are contained in each listing, and how many of these are occupied
- `TotalUnits` defaults to 1, `OccupiedUnits` defaults to 0
- SQL check constraint enforces `OccupiedUnits <= TotalUnits`
- Overall property keeps its availability states, but is forced into the Occupied state if all its units are occupied (i.e. `OccupiedUnits == TotalUnits`)
- Any future work which alters `TotalUnits` or `OccupiedUnits` in a different method should make sure the above holds, but the `UpdateProperty` method will likely be sufficient
- Number of available units is calculated as `TotalUnits - OccupiedUnits`