### PR TITLE
BNH-97 Add address to landlord

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandLordControllerUnassignedTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandLordControllerUnassignedTests.cs
@@ -40,11 +40,13 @@ public class LandLordControllerUnassignedTests : LandlordControllerTestsBase
             A<string>.That.Matches(s => s == msgBody), A<string>.That.Matches(s => s == subject), A<string>.Ignored,
             A<string>.Ignored
         )).WithAnyArguments().DoesNothing();
+
         // Act
         var result = await UnderTest.RegisterPost(formResultModel) as RedirectToActionResult;
+
         // Assert
         A.CallTo(() => MailService.TrySendMsgInBackground(
-            A<string>.That.Matches(s=>s==msgBody), A<string>.That.Matches(s=>s==subject)
+            A<string>.That.Matches(s => s == msgBody), A<string>.That.Matches(s => s == subject)
         )).WithAnyArguments().MustHaveHappened();
         A.CallTo(() => LandlordService.RegisterLandlord(formResultModel)).MustHaveHappened();
         result.Should().BeOfType<RedirectToActionResult>();

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
@@ -34,7 +34,7 @@ public class LandlordControllerTestsBase : ControllerTestsBase
     {
         return new PropertyViewModel
         {
-            Address = new PropertyAddress
+            Address = new AddressModel
             {
                 AddressLine1 = "Adr1",
                 AddressLine2 = "Adr2",

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using BricksAndHearts.Controllers;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using FakeItEasy;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 
@@ -28,6 +32,8 @@ public class LandlordControllerTestsBase : ControllerTestsBase
         var tempData = new TempDataDictionary(httpContext, A.Fake<ITempDataProvider>());
         UnderTest = new LandlordController(Logger, LandlordService, PropertyService, MailService)
             { TempData = tempData };
+        // Fixes NullReferenceException when calling TryValidateModel()
+        UnderTest.ObjectValidator = new CustomObjectValidator();
     }
 
     protected PropertyViewModel CreateExamplePropertyViewModel()
@@ -41,7 +47,7 @@ public class LandlordControllerTestsBase : ControllerTestsBase
                 AddressLine3 = "Adr3",
                 TownOrCity = "City",
                 County = "County",
-                Postcode = "Postcode"
+                Postcode = "CB21LA"
             },
             PropertyType = "Type",
             NumOfBedrooms = 2,
@@ -62,7 +68,16 @@ public class LandlordControllerTestsBase : ControllerTestsBase
             CompanyName = "John Doe",
             Email = "test.email@gmail.com",
             CharterApproved = false,
-            LandlordType = "some data"
+            LandlordType = "some data",
+            Address = new AddressModel
+            {
+                AddressLine1 = "Adr1",
+                AddressLine2 = "Adr2",
+                AddressLine3 = "Adr3",
+                TownOrCity = "City",
+                County = "County",
+                Postcode = "CB21LA"
+            }
         };
     }
 
@@ -75,7 +90,38 @@ public class LandlordControllerTestsBase : ControllerTestsBase
             LastName = "Doe",
             CompanyName = "John Doe",
             CharterApproved = false,
-            LandlordType = "some data"
+            LandlordType = "some data",
+            Address = new AddressModel
+            {
+                AddressLine1 = "Adr1",
+                AddressLine2 = "Adr2",
+                AddressLine3 = "Adr3",
+                TownOrCity = "City",
+                County = "County",
+                Postcode = "CB21LA"
+            }
         };
+    }
+
+    public class CustomObjectValidator : IObjectModelValidator
+    {
+        public void Validate(ActionContext actionContext, ValidationStateDictionary? validationState, string prefix,
+            object? model)
+        {
+            var context = new ValidationContext(model!, serviceProvider: null, items: null);
+            var results = new List<ValidationResult>();
+
+            bool isValid = Validator.TryValidateObject(
+                model!, context, results,
+                validateAllProperties: true
+            );
+
+            if (!isValid)
+                results.ForEach(r =>
+                {
+                    // Add validation errors to the ModelState
+                    actionContext.ModelState.AddModelError("", r.ErrorMessage!);
+                });
+        }
     }
 }

--- a/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
@@ -338,7 +338,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
 
         var formResultModel = new PropertyViewModel
         {
-            Address = new PropertyAddress(),
+            Address = new AddressModel(),
             LandlordId = 1
         };
 
@@ -364,7 +364,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
 
         var formResultModel = new PropertyViewModel
         {
-            Address = new PropertyAddress
+            Address = new AddressModel
             {
                 AddressLine1 = "Line 1",
                 Postcode = "Postcode"

--- a/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTestsBase.cs
@@ -35,7 +35,7 @@ public class PropertyControllerTestsBase : ControllerTestsBase
     {
         return new PropertyViewModel
         {
-            Address = new PropertyAddress
+            Address = new AddressModel
             {
                 AddressLine1 = "Adr1",
                 AddressLine2 = "Adr2",

--- a/BricksAndHearts.UnitTests/ServiceTests/Property/PropertyServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Property/PropertyServiceTests.cs
@@ -51,7 +51,7 @@ public class PropertyServiceTests : PropertyServiceTestsBase
         var propertiesBeforeCount = context.Properties.Count();
         var createModel = new PropertyViewModel
         {
-            Address = new PropertyAddress
+            Address = new AddressModel
             {
                 AddressLine1 = "AddNewProperty_AddsNewProperty",
                 County = "Cambridgeshire",
@@ -109,7 +109,7 @@ public class PropertyServiceTests : PropertyServiceTestsBase
         var propertiesBeforeCount = context.Properties.Count();
         var updateModel = new PropertyViewModel
         {
-            Address = new PropertyAddress
+            Address = new AddressModel
             {
                 AddressLine1 = "UpdateProperty_UpdatesProperty1",
                 County = "Cambridgeshire",
@@ -387,17 +387,17 @@ public class PropertyServiceTests : PropertyServiceTestsBase
     }
 
     #endregion
-    
+
     [Fact]
     public void CreateNewPublicViewLink_UpdateDatabase()
     {
         // Arrange
         using var context = Fixture.CreateWriteContext();
         var service = new PropertyService(context);
-        
+
         // Act
         var result = service.CreateNewPublicViewLink(1);
-        
+
         // Assert
         result.Should().NotBeNullOrEmpty();
         context.Properties.Single(p => p.Id == 1).PublicViewLink.Should().Be(result);

--- a/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
@@ -196,7 +196,13 @@ public class TestDatabaseFixture
             Phone = "01189998819991197253",
             LandlordType = "Non profit",
             CharterApproved = true,
-            MembershipId = "member1"
+            MembershipId = "member1",
+            AddressLine1 = "adr1",
+            AddressLine2 = "adr2",
+            AddressLine3 = "adr3",
+            TownOrCity = "city",
+            County = "county",
+            Postcode = "cb2 1la"
         };
     }
 
@@ -210,7 +216,13 @@ public class TestDatabaseFixture
             Title = "Mr",
             Phone = "01189998819991197253",
             LandlordType = "Non profit",
-            CharterApproved = false
+            CharterApproved = false,
+            AddressLine1 = "adr1",
+            AddressLine2 = "adr2",
+            AddressLine3 = "adr3",
+            TownOrCity = "city",
+            County = "county",
+            Postcode = "cb2 1la"
         };
     }
 
@@ -225,7 +237,13 @@ public class TestDatabaseFixture
             Phone = "01189998819991197253",
             LandlordType = "Non profit",
             CharterApproved = true,
-            InviteLink = "InvitimusLinkimus"
+            InviteLink = "InvitimusLinkimus",
+            AddressLine1 = "adr1",
+            AddressLine2 = "adr2",
+            AddressLine3 = "adr3",
+            TownOrCity = "city",
+            County = "county",
+            Postcode = "cb2 1la"
         };
     }
 
@@ -240,7 +258,13 @@ public class TestDatabaseFixture
             Phone = "004",
             LandlordType = "Non profit",
             CharterApproved = true,
-            InviteLink = "invite-unlinked-landlord"
+            InviteLink = "invite-unlinked-landlord",
+            AddressLine1 = "adr1",
+            AddressLine2 = "adr2",
+            AddressLine3 = "adr3",
+            TownOrCity = "city",
+            County = "county",
+            Postcode = "cb2 1la"
         };
     }
 

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -51,9 +51,9 @@ public class LandlordController : AbstractController
     public async Task<ActionResult> RegisterPost([FromForm] LandlordProfileModel createModel)
     {
         // This does checks based on the annotations (e.g. [Required]) on LandlordProfileModel
-        if (!ModelState.IsValid)
+        if (!ModelState.IsValid || !TryValidateModel(createModel.Address, nameof(AddressModel)))
         {
-            return View("Register");
+            return View("Register", createModel);
         }
 
         var user = GetCurrentUser();
@@ -235,7 +235,7 @@ public class LandlordController : AbstractController
     public async Task<ActionResult> EditProfileUpdate([FromForm] LandlordProfileModel editModel)
     {
         var user = GetCurrentUser();
-        if (!ModelState.IsValid)
+        if (!ModelState.IsValid || !TryValidateModel(editModel.Address, nameof(AddressModel)))
         {
             return StatusCode(404);
         }

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -134,7 +134,7 @@ public class PropertyController : AbstractController
     public ActionResult AddNewProperty_Continue([FromRoute] int step, [FromQuery] int propertyId,
         int? landlordId = null)
     {
-        var newPropertyModel = new PropertyViewModel { Address = new PropertyAddress() };
+        var newPropertyModel = new PropertyViewModel { Address = new AddressModel() };
         landlordId ??= GetCurrentUser().LandlordId!.Value;
 
         if (propertyId != 0)

--- a/web/Database/LandlordDbModel.cs
+++ b/web/Database/LandlordDbModel.cs
@@ -13,6 +13,14 @@ public class LandlordDbModel
     public string Email { get; set; } = null!;
     public string Phone { get; set; } = null!;
 
+    // Address
+    public string AddressLine1 { get; set; } = null!;
+    public string? AddressLine2 { get; set; }
+    public string? AddressLine3 { get; set; }
+    public string TownOrCity { get; set; } = null!;
+    public string County { get; set; } = null!;
+    public string Postcode { get; set; } = null!;
+
     //Type of landlord
     public string LandlordType { get; set; } = null!;
 

--- a/web/Migrations/20220810130152_AddAddressToLandlord.Designer.cs
+++ b/web/Migrations/20220810130152_AddAddressToLandlord.Designer.cs
@@ -4,6 +4,7 @@ using BricksAndHearts.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BricksAndHearts.Migrations
 {
     [DbContext(typeof(BricksAndHeartsDbContext))]
-    partial class BricksAndHeartsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220810130152_AddAddressToLandlord")]
+    partial class AddAddressToLandlord
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/web/Migrations/20220810130152_AddAddressToLandlord.cs
+++ b/web/Migrations/20220810130152_AddAddressToLandlord.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BricksAndHearts.Migrations
+{
+    public partial class AddAddressToLandlord : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AddressLine1",
+                table: "Landlord",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AddressLine2",
+                table: "Landlord",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AddressLine3",
+                table: "Landlord",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "County",
+                table: "Landlord",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Postcode",
+                table: "Landlord",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "TownOrCity",
+                table: "Landlord",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AddressLine1",
+                table: "Landlord");
+
+            migrationBuilder.DropColumn(
+                name: "AddressLine2",
+                table: "Landlord");
+
+            migrationBuilder.DropColumn(
+                name: "AddressLine3",
+                table: "Landlord");
+
+            migrationBuilder.DropColumn(
+                name: "County",
+                table: "Landlord");
+
+            migrationBuilder.DropColumn(
+                name: "Postcode",
+                table: "Landlord");
+
+            migrationBuilder.DropColumn(
+                name: "TownOrCity",
+                table: "Landlord");
+        }
+    }
+}

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -78,7 +78,13 @@ public class LandlordService : ILandlordService
             Phone = createModel.Phone,
             LandlordType = createModel.LandlordType,
             IsLandlordForProfit = createModel.IsLandlordForProfit,
-            MembershipId = createModel.MembershipId
+            MembershipId = createModel.MembershipId,
+            AddressLine1 = createModel.Address.AddressLine1!,
+            AddressLine2 = createModel.Address.AddressLine2,
+            AddressLine3 = createModel.Address.AddressLine3,
+            TownOrCity = createModel.Address.TownOrCity!,
+            County = createModel.Address.County!,
+            Postcode = createModel.Address.Postcode!
         };
 
         await using (var transaction = await _dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable))
@@ -145,7 +151,13 @@ public class LandlordService : ILandlordService
             Phone = createModel.Phone,
             LandlordType = createModel.LandlordType,
             IsLandlordForProfit = createModel.IsLandlordForProfit,
-            MembershipId = createModel.MembershipId
+            MembershipId = createModel.MembershipId,
+            AddressLine1 = createModel.Address.AddressLine1!,
+            AddressLine2 = createModel.Address.AddressLine2,
+            AddressLine3 = createModel.Address.AddressLine3,
+            TownOrCity = createModel.Address.TownOrCity!,
+            County = createModel.Address.County!,
+            Postcode = createModel.Address.Postcode!
         };
 
         await using (var transaction = await _dbContext.Database.BeginTransactionAsync(IsolationLevel.Serializable))
@@ -224,6 +236,12 @@ public class LandlordService : ILandlordService
         landlordToEdit.LandlordType = editModel.LandlordType;
         landlordToEdit.IsLandlordForProfit = editModel.IsLandlordForProfit;
         landlordToEdit.MembershipId = editModel.MembershipId;
+        landlordToEdit.AddressLine1 = editModel.Address.AddressLine1!;
+        landlordToEdit.AddressLine2 = editModel.Address.AddressLine2;
+        landlordToEdit.AddressLine3 = editModel.Address.AddressLine3;
+        landlordToEdit.TownOrCity = editModel.Address.TownOrCity!;
+        landlordToEdit.County = editModel.Address.County!;
+        landlordToEdit.Postcode = editModel.Address.Postcode!;
 
         await _dbContext.SaveChangesAsync();
         return ILandlordService.LandlordRegistrationResult.Success;

--- a/web/ViewModels/AddressModel.cs
+++ b/web/ViewModels/AddressModel.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace BricksAndHearts.ViewModels;
+
+public class AddressModel
+{
+    [StringLength(10000)]
+    public string? AddressLine1 { get; set; }
+
+    [StringLength(10000)]
+    public string? AddressLine2 { get; set; }
+
+    [StringLength(10000)]
+    public string? AddressLine3 { get; set; }
+
+    [StringLength(10000)]
+    public string? TownOrCity { get; set; }
+
+    [StringLength(10000)]
+    public string? County { get; set; }
+
+    [RegularExpression(
+        @"([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})",
+        ErrorMessage = "Please enter a valid postcode")]
+    public string? Postcode { get; set; }
+}

--- a/web/ViewModels/LandlordProfileModel.cs
+++ b/web/ViewModels/LandlordProfileModel.cs
@@ -6,7 +6,7 @@ namespace BricksAndHearts.ViewModels;
 
 public class LandlordProfileModel
 {
-    [DisplayName("Id")]
+    [DisplayName("ID")]
     public int? LandlordId { get; set; }
 
     [Required]
@@ -16,13 +16,16 @@ public class LandlordProfileModel
 
     [Required]
     [StringLength(255)]
-    [DisplayName("First Name")]
+    [DisplayName("First name")]
     public string FirstName { get; set; } = string.Empty;
 
     [Required]
     [StringLength(255)]
-    [DisplayName("Last Name")]
+    [DisplayName("Last name")]
     public string LastName { get; set; } = string.Empty;
+
+    [Required]
+    public AddressModel Address { get; set; } = new();
 
     [StringLength(1000)]
     [DisplayName("Company")]
@@ -68,7 +71,16 @@ public class LandlordProfileModel
             CharterApproved = landlord.CharterApproved,
             IsLandlordForProfit = landlord.IsLandlordForProfit,
             NumOfProperties = landlord.Properties.Count,
-            InviteLink = landlord.InviteLink
+            InviteLink = landlord.InviteLink,
+            Address = new AddressModel
+            {
+                AddressLine1 = landlord.AddressLine1,
+                AddressLine2 = landlord.AddressLine2,
+                AddressLine3 = landlord.AddressLine3,
+                TownOrCity = landlord.TownOrCity,
+                County = landlord.County,
+                Postcode = landlord.Postcode
+            }
         };
     }
 }

--- a/web/ViewModels/PropertyViewModel.cs
+++ b/web/ViewModels/PropertyViewModel.cs
@@ -13,7 +13,7 @@ public class PropertyViewModel : IValidatableObject
 
 
     // Location
-    public PropertyAddress Address { get; set; } = new();
+    public AddressModel Address { get; set; } = new();
     public decimal? Lat { get; set; }
     public decimal? Lon { get; set; }
 
@@ -100,7 +100,7 @@ public class PropertyViewModel : IValidatableObject
             Description = property.Description,
             Lat = property.Lat,
             Lon = property.Lon,
-            Address = new PropertyAddress
+            Address = new AddressModel
             {
                 AddressLine1 = property.AddressLine1,
                 AddressLine2 = property.AddressLine2,
@@ -122,27 +122,4 @@ public class PropertyViewModel : IValidatableObject
             OccupiedUnits = property.OccupiedUnits
         };
     }
-}
-
-public class PropertyAddress
-{
-    [StringLength(10000)]
-    public string? AddressLine1 { get; set; }
-
-    [StringLength(10000)]
-    public string? AddressLine2 { get; set; }
-
-    [StringLength(10000)]
-    public string? AddressLine3 { get; set; }
-
-    [StringLength(10000)]
-    public string? TownOrCity { get; set; }
-
-    [StringLength(10000)]
-    public string? County { get; set; }
-
-    [RegularExpression(
-        @"([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})",
-        ErrorMessage = "Please enter a valid postcode")]
-    public string? Postcode { get; set; }
 }

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -37,18 +37,24 @@
         <div class="mb-4">
             <div class="d-flex">
                 <h3 class="font-h3 d-inline-block">Address</h3>
-                <a class="bi bi-pencil ms-auto"></a>
+                <a class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(1);"></a>
             </div>
             <table class="table">
                 <tr>
                     <th class="w-25">Address</th>
                     <td>
-                        Softwire,<br/>
-                        Charter House,<br/>
-                        62-64 Hills Rd,<br/>
-                        Cambridge,<br/>
-                        Cambridgeshire<br/>
-                        CB2 1LA<br/>
+                        <div>@Model.Address.AddressLine1,</div>
+                        @if (Model.Address.AddressLine2 != null)
+                        {
+                            <div>@Model.Address.AddressLine2,</div>
+                        }
+                        @if (Model.Address.AddressLine3 != null)
+                        {
+                            <div>@Model.Address.AddressLine3,</div>
+                        }
+                        <div>@Model.Address.TownOrCity,</div>
+                        <div>@Model.Address.County,</div>
+                        <div>@Model.Address.Postcode,</div>
                     </td>
                 </tr>
                 <tr>

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -54,7 +54,7 @@
                         }
                         <div>@Model.Address.TownOrCity,</div>
                         <div>@Model.Address.County,</div>
-                        <div>@Model.Address.Postcode,</div>
+                        <div>@Model.Address.Postcode</div>
                     </td>
                 </tr>
                 <tr>

--- a/web/Views/Landlord/_RegisterPagePartial.cshtml
+++ b/web/Views/Landlord/_RegisterPagePartial.cshtml
@@ -25,7 +25,37 @@
     </div>
 </div>
 
-<div class="registerTab col-md-5" id="Contact details">
+<div class="registerTab col-md-5 row" id="Contact details">
+    <div class="my-3">
+        <label asp-for="Address.AddressLine1" class="form-label">Address Line 1</label>
+        <input asp-for="Address.AddressLine1" class="form-control" required/>
+        <span asp-validation-for="Address.AddressLine1" class="text-danger"></span>
+    </div>
+    <div class="my-3">
+        <label asp-for="Address.AddressLine2" class="form-label">Address Line 2</label>
+        <input asp-for="Address.AddressLine2" class="form-control empty"/>
+        <span asp-validation-for="Address.AddressLine2" class="text-danger"></span>
+    </div>
+    <div class="my-3">
+        <label asp-for="Address.AddressLine3" class="form-label">Address Line 3</label>
+        <input asp-for="Address.AddressLine3" class="form-control empty"/>
+        <span asp-validation-for="Address.AddressLine3" class="text-danger"></span>
+    </div>
+    <div class="my-3">
+        <label asp-for="Address.TownOrCity" class="form-label">Town or City</label>
+        <input asp-for="Address.TownOrCity" class="form-control" required/>
+        <span asp-validation-for="Address.TownOrCity" class="text-danger"></span>
+    </div>
+    <div class="my-3">
+        <label asp-for="Address.County" class="form-label">County</label>
+        <input asp-for="Address.County" class="form-control" required/>
+        <span asp-validation-for="Address.County" class="text-danger"></span>
+    </div>
+    <div class="my-3">
+        <label asp-for="Address.Postcode" class="form-label">Postcode</label>
+        <input asp-for="Address.Postcode" class="form-control" required/>
+        <span asp-validation-for="Address.Postcode" class="text-danger"></span>
+    </div>
     <div class="form-group my-3">
         <label asp-for="Email" class="form-label"></label>
         <input type="email" asp-for="Email" class="form-control"/>


### PR DESCRIPTION
- Landlords now have an address!
- `PropertyAddress` has been refactored to be `AddressModel` and is shared by properties and landlords
- The address has been added to the landlord register form (mostly at random as this form will be restyled in the future)
- The landlord profile page now displays their address instead of a placeholder, and the corresponding edit button is now functional