### PR TITLE
BNH-127 - add AdminControllerTests

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -12,7 +12,7 @@ namespace BricksAndHearts.UnitTests.ControllerTests.Admin;
 public class AdminControllerTests : AdminControllerTestsBase
 {
     [Fact]
-    public void Index_WhenCalledByAnonymousUser_ReturnsViewWithLoginLink()
+    public void AdminDashboard_WhenCalledByAnonymousUser_ReturnsViewWithLoginLink()
     {
         // Arrange
         UnderTest.ControllerContext = new ControllerContext
@@ -27,9 +27,195 @@ public class AdminControllerTests : AdminControllerTestsBase
         result!.ViewData.Model.Should().BeOfType<AdminDashboardViewModel>()
             .Which.CurrentUser.Should().BeNull();
     }
+    
+    [Fact]
+    public void AdminDashboard_WhenCalledByNonAdminUser_ReturnsViewWithLoginLink()
+    {
+        // Arrange
+        var nonAdminNonLandlordUser = CreateNonAdminNonLandlordUser();
+        MakeUserPrincipalInController(nonAdminNonLandlordUser, UnderTest);
+
+        // Act
+        var result = UnderTest.AdminDashboard() as ViewResult;
+
+        // Assert
+        result!.ViewData.Model.Should().BeOfType<AdminDashboardViewModel>()
+            .Which.CurrentUser!.IsAdmin.Should().Be(false);
+    }
+    
+    [Fact]
+    public void AdminDashboard_WhenCalledByAdminUser_ReturnsViewWithLoginLink()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+
+        // Act
+        var result = UnderTest.AdminDashboard() as ViewResult;
+
+        // Assert
+        result!.ViewData.Model.Should().BeOfType<AdminDashboardViewModel>()
+            .Which.CurrentUser!.IsAdmin.Should().Be(true);
+    }
 
     [Fact]
-    public async void LandlordList_WhenCalled_CallsGetLandlordListAndReturnsLandlordListView()
+    public void RequestAdminAccess_WhenCalledByNonAdmin_CallsRequestAdminAccessAndRedirectsToAdminDashboard()
+    {
+        // Arrange
+        var nonAdminNonLandlordUser = CreateNonAdminNonLandlordUser();
+        MakeUserPrincipalInController(nonAdminNonLandlordUser, UnderTest);
+
+        // Act
+        var result = UnderTest.RequestAdminAccess() as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.RequestAdminAccess(nonAdminNonLandlordUser)).MustHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("AdminDashboard");
+    }
+    
+    [Fact]
+    public void RequestAdminAccess_WhenCalledByAdmin_RedirectsToAdminDashboardView()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+
+        // Act
+        var result = UnderTest.RequestAdminAccess() as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.RequestAdminAccess(adminUser)).MustNotHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("AdminDashboard");
+    }
+    
+    [Fact]
+    public void CancelAdminAccess_WhenCalledByNonAdmin_CallsCancelAdminAccessRequestAndRedirectsToAdminDashboard()
+    {
+        // Arrange
+        var nonAdminNonLandlordUser = CreateNonAdminNonLandlordUser();
+        MakeUserPrincipalInController(nonAdminNonLandlordUser, UnderTest);
+
+        // Act
+        var result = UnderTest.CancelAdminAccessRequest() as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.CancelAdminAccessRequest(nonAdminNonLandlordUser)).MustHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("AdminDashboard");
+    }
+    
+    [Fact]
+    public void CancelAdminAccess_WhenCalledByAdmin_RedirectsToAdminDashboardView()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+
+        // Act
+        var result = UnderTest.CancelAdminAccessRequest() as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.CancelAdminAccessRequest(adminUser)).MustNotHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("AdminDashboard");
+    }
+    
+    [Fact]
+    public void AcceptAdminRequest_OnInvalidUserId_CallsGetUserFromIdAndReturnsErrorView()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        A.CallTo(() => AdminService.GetUserFromId(1)).Returns(null);
+
+        // Act
+        var result = UnderTest.AcceptAdminRequest(1) as ViewResult;
+
+        // Assert
+        A.CallTo(() => AdminService.GetUserFromId(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.ApproveAdminAccessRequest(1)).MustNotHaveHappened();
+        result!.ViewData.Model.Should().BeOfType<ErrorViewModel>();
+    }
+    
+    [Fact]
+    public void AcceptAdminRequest_OnValidUserId_CallsGetUserFromThenCallsApproveAdminAccessRequestAndRedirectsToGetAdminList()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        var userDbModel = CreateUserDbModel(false, false);
+        A.CallTo(() => AdminService.GetUserFromId(1)).Returns(userDbModel);
+
+        // Act
+        var result = UnderTest.AcceptAdminRequest(1) as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.GetUserFromId(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.ApproveAdminAccessRequest(1)).MustHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("GetAdminList");
+    }
+    
+    [Fact]
+    public void RejectAdminRequest_OnInvalidUserId_CallsRejectAdminAccessRequestAndRedirectsToGetAdminList()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        A.CallTo(() => AdminService.GetUserFromId(1)).Returns(null);
+
+        // Act
+        var result = UnderTest.RejectAdminRequest(1) as ViewResult;
+
+        // Assert
+        A.CallTo(() => AdminService.GetUserFromId(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.RejectAdminAccessRequest(1)).MustNotHaveHappened();
+        result!.ViewData.Model.Should().BeOfType<ErrorViewModel>();
+    }
+    
+    [Fact]
+    public void RejectAdminRequest_OnValidUserId_CallsGetUserFromThenCallsRejectAdminAccessRequestAndRedirectsToGetAdminList()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        var userDbModel = CreateUserDbModel(false, false);
+        A.CallTo(() => AdminService.GetUserFromId(1)).Returns(userDbModel);
+
+        // Act
+        var result = UnderTest.RejectAdminRequest(1) as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.GetUserFromId(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.RejectAdminAccessRequest(1)).MustHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("GetAdminList");
+    }
+
+    [Fact]
+    public void GetAdminList_CallsGetAdminListsAndReturnsViewWithAdminListModel()
+    {
+        // Arrange
+        MakeUserPrincipalInController(CreateAdminUser(), UnderTest);
+
+        // Act
+        var result = UnderTest.GetAdminList().Result as ViewResult;
+
+        // Assert
+        A.CallTo(() => AdminService.GetAdminLists()).MustHaveHappened();
+        result!.ViewData.Model.Should().BeOfType<AdminListModel>();
+    }
+    
+    [Fact]
+    public async void LandlordList_CallsGetLandlordListAndReturnsLandlordListView()
     {
         // Arrange
         var adminUser = CreateAdminUser();
@@ -44,7 +230,7 @@ public class AdminControllerTests : AdminControllerTestsBase
     }
     
     [Fact]
-    public async void TenantList_WhenCalled_CallsGetTenantListAndReturnsTenantListView()
+    public async void TenantList_CallsGetTenantListAndReturnsTenantListView()
     {
         // Arrange
         var adminUser = CreateAdminUser();
@@ -57,19 +243,139 @@ public class AdminControllerTests : AdminControllerTestsBase
         A.CallTo(() => AdminService.GetTenantList()).MustHaveHappened();
         result!.ViewData.Model.Should().BeOfType<TenantListModel?>();
     }
-
+    
     [Fact]
-    public void GetAdminList_WhenCalled_CallsGetAdminListsAndReturnsViewWithAdminListModel()
+    public void GetInviteLink_CalledOnLinkedLandlord_CallsFindUserByLandlordIdAndRedirectsToLandlordProfileWithWarningFLash()
     {
         // Arrange
-        MakeUserPrincipalInController(CreateAdminUser(), UnderTest);
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        var landlordUser = CreateUserDbModel(false, true);
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).Returns(landlordUser);
 
         // Act
-        var result = UnderTest.GetAdminList().Result as ViewResult;
+        var result = UnderTest.GetInviteLink(1) as RedirectToActionResult;
 
         // Assert
-        A.CallTo(() => AdminService.GetAdminLists()).MustHaveHappened();
-        result!.ViewData.Model.Should().BeOfType<AdminListModel>();
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.FindExistingInviteLink(1)).MustNotHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("Profile");
+        UnderTest.TempData["FlashMessage"].Should().Be($"Landlord already linked to user {landlordUser.GoogleUserName}");
+    }
+    
+    [Fact]
+    public void GetInviteLink_CalledOnUnlinkedLandlordWithoutExistingLink_CallsFindExistingInviteLinkThenCallsCreateNewInviteLinkAndRedirectsToLandlordProfileWithSuccessFlash()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).Returns(null);
+        A.CallTo(() => AdminService.FindExistingInviteLink(1)).Returns(null);
+        A.CallTo(() => AdminService.CreateNewInviteLink(1)).Returns("new link");
+
+        // Act
+        var result = UnderTest.GetInviteLink(1) as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.FindExistingInviteLink(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.CreateNewInviteLink(1)).MustHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("Profile");
+        UnderTest.TempData["FlashMessage"].Should().Be("Successfully created a new invite link: new link");
+    }
+    
+    [Fact]
+    public void GetInviteLink_CalledOnUnlinkedLandlordWithExistingLink_CallsFindExistingInviteLinkAndRedirectsToLandlordProfileWithSuccessFlash()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).Returns(null);
+        A.CallTo(() => AdminService.FindExistingInviteLink(1)).Returns("existing link");
+
+        // Act
+        var result = UnderTest.GetInviteLink(1) as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.FindExistingInviteLink(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.CreateNewInviteLink(1)).MustNotHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("Profile");
+        UnderTest.TempData["FlashMessage"].Should().Be("Landlord already has an invite link: existing link");
+    }
+    
+        [Fact]
+    public void RenewInviteLink_CalledOnLinkedLandlord_CallsFindUserByLandlordIdAndRedirectsToLandlordProfileWithFLash()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        var landlordUser = CreateUserDbModel(false, true);
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).Returns(landlordUser);
+
+        // Act
+        var result = UnderTest.RenewInviteLink(1) as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.FindExistingInviteLink(1)).MustNotHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("Profile");
+        UnderTest.TempData["InviteLinkMessage"].Should().Be($"Landlord already linked to user {landlordUser.GoogleUserName}");
+    }
+    
+    [Fact]
+    public void RenewInviteLink_CalledOnUnlinkedLandlordWithoutExistingLink_CallsFindExistingInviteLinkThenCallsCreateNewInviteLinkAndRedirectsToLandlordProfileWithSuccessFlash()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).Returns(null);
+        A.CallTo(() => AdminService.FindExistingInviteLink(1)).Returns(null);
+        A.CallTo(() => AdminService.CreateNewInviteLink(1)).Returns("new link");
+
+        // Act
+        var result = UnderTest.RenewInviteLink(1) as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.FindExistingInviteLink(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.DeleteExistingInviteLink(1)).MustNotHaveHappened();
+        A.CallTo(() => AdminService.CreateNewInviteLink(1)).MustHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("Profile");
+        UnderTest.TempData["InviteLinkMessage"].Should().Be("No existing invite link. Successfully created a new invite link :)");
+    }
+    
+    [Fact]
+    public void RenewInviteLink_CalledOnUnlinkedLandlordWithExistingLink_CallsFindExistingInviteLinkThenCallsDeleteExistingLinkThenCallsCreateNewInviteLinkAndRedirectsToLandlordProfileWithSuccessFlash()
+    {
+        // Arrange
+        var adminUser = CreateAdminUser();
+        MakeUserPrincipalInController(adminUser, UnderTest);
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).Returns(null);
+        A.CallTo(() => AdminService.FindExistingInviteLink(1)).Returns("existing link");
+
+        // Act
+        var result = UnderTest.RenewInviteLink(1) as RedirectToActionResult;
+
+        // Assert
+        A.CallTo(() => AdminService.FindUserByLandlordId(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.FindExistingInviteLink(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.DeleteExistingInviteLink(1)).MustHaveHappened();
+        A.CallTo(() => AdminService.CreateNewInviteLink(1)).MustHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>();
+        result.Should().NotBeNull();
+        result!.ActionName.Should().BeEquivalentTo("Profile");
+        UnderTest.TempData["InviteLinkMessage"].Should().Be("Successfully created a new invite link :)");
     }
 
     [Fact]

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -125,75 +125,35 @@ public class AdminControllerTests : AdminControllerTestsBase
         result.Should().NotBeNull();
         result!.ActionName.Should().BeEquivalentTo("AdminDashboard");
     }
-    
+
     [Fact]
-    public void AcceptAdminRequest_OnInvalidUserId_CallsGetUserFromIdAndReturnsErrorView()
+    public void AcceptAdminRequest_CallsGetUserFromThenCallsApproveAdminAccessRequestAndRedirectsToGetAdminList()
     {
         // Arrange
         var adminUser = CreateAdminUser();
         MakeUserPrincipalInController(adminUser, UnderTest);
-        A.CallTo(() => AdminService.GetUserFromId(1)).Returns(null);
-
-        // Act
-        var result = UnderTest.AcceptAdminRequest(1) as ViewResult;
-
-        // Assert
-        A.CallTo(() => AdminService.GetUserFromId(1)).MustHaveHappened();
-        A.CallTo(() => AdminService.ApproveAdminAccessRequest(1)).MustNotHaveHappened();
-        result!.ViewData.Model.Should().BeOfType<ErrorViewModel>();
-    }
-    
-    [Fact]
-    public void AcceptAdminRequest_OnValidUserId_CallsGetUserFromThenCallsApproveAdminAccessRequestAndRedirectsToGetAdminList()
-    {
-        // Arrange
-        var adminUser = CreateAdminUser();
-        MakeUserPrincipalInController(adminUser, UnderTest);
-        var userDbModel = CreateUserDbModel(false, false);
-        A.CallTo(() => AdminService.GetUserFromId(1)).Returns(userDbModel);
 
         // Act
         var result = UnderTest.AcceptAdminRequest(1) as RedirectToActionResult;
 
         // Assert
-        A.CallTo(() => AdminService.GetUserFromId(1)).MustHaveHappened();
         A.CallTo(() => AdminService.ApproveAdminAccessRequest(1)).MustHaveHappened();
         result.Should().BeOfType<RedirectToActionResult>();
         result.Should().NotBeNull();
         result!.ActionName.Should().BeEquivalentTo("GetAdminList");
     }
-    
-    [Fact]
-    public void RejectAdminRequest_OnInvalidUserId_CallsRejectAdminAccessRequestAndRedirectsToGetAdminList()
-    {
-        // Arrange
-        var adminUser = CreateAdminUser();
-        MakeUserPrincipalInController(adminUser, UnderTest);
-        A.CallTo(() => AdminService.GetUserFromId(1)).Returns(null);
 
-        // Act
-        var result = UnderTest.RejectAdminRequest(1) as ViewResult;
-
-        // Assert
-        A.CallTo(() => AdminService.GetUserFromId(1)).MustHaveHappened();
-        A.CallTo(() => AdminService.RejectAdminAccessRequest(1)).MustNotHaveHappened();
-        result!.ViewData.Model.Should().BeOfType<ErrorViewModel>();
-    }
-    
     [Fact]
     public void RejectAdminRequest_OnValidUserId_CallsGetUserFromThenCallsRejectAdminAccessRequestAndRedirectsToGetAdminList()
     {
         // Arrange
         var adminUser = CreateAdminUser();
         MakeUserPrincipalInController(adminUser, UnderTest);
-        var userDbModel = CreateUserDbModel(false, false);
-        A.CallTo(() => AdminService.GetUserFromId(1)).Returns(userDbModel);
 
         // Act
         var result = UnderTest.RejectAdminRequest(1) as RedirectToActionResult;
 
         // Assert
-        A.CallTo(() => AdminService.GetUserFromId(1)).MustHaveHappened();
         A.CallTo(() => AdminService.RejectAdminAccessRequest(1)).MustHaveHappened();
         result.Should().BeOfType<RedirectToActionResult>();
         result.Should().NotBeNull();

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -245,7 +245,7 @@ public class AdminControllerTests : AdminControllerTestsBase
         result.Should().BeOfType<RedirectToActionResult>();
         result.Should().NotBeNull();
         result!.ActionName.Should().BeEquivalentTo("Profile");
-        UnderTest.TempData["FlashMessage"].Should().Be("Successfully created a new invite link: new link");
+        UnderTest.TempData["FlashMessage"].Should().Be("Successfully created a new invite link: http:///invite/new link");
     }
     
     [Fact]
@@ -267,7 +267,7 @@ public class AdminControllerTests : AdminControllerTestsBase
         result.Should().BeOfType<RedirectToActionResult>();
         result.Should().NotBeNull();
         result!.ActionName.Should().BeEquivalentTo("Profile");
-        UnderTest.TempData["FlashMessage"].Should().Be("Landlord already has an invite link: existing link");
+        UnderTest.TempData["FlashMessage"].Should().Be("Landlord already has an invite link: http:///invite/existing link");
     }
     
         [Fact]

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
@@ -12,9 +12,9 @@ public class AdminControllerTestsBase : ControllerTestsBase
 {
     protected readonly ILogger<AdminController> Logger;
     protected readonly IAdminService AdminService;
-    protected readonly ICsvImportService CsvImportService;
     protected readonly ILandlordService LandlordService;
     protected readonly IPropertyService PropertyService;
+    protected readonly ICsvImportService CsvImportService;
     protected readonly AdminController UnderTest;
 
     protected AdminControllerTestsBase()

--- a/BricksAndHearts.UnitTests/ControllerTests/ControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/ControllerTestsBase.cs
@@ -22,6 +22,33 @@ public class ControllerTestsBase
     }
     
     // Create a user that is logged into Google but is not a landlord or admin
+    protected UserDbModel CreateUserDbModel(bool isAdmin, bool isLandlord)
+    {
+        var userDbModel = new UserDbModel()
+        {
+            Id = 1,
+            GoogleUserName = "John Doe",
+            GoogleEmail = "test.email@gmail.com",
+            IsAdmin = isAdmin,
+        };
+        if (isLandlord)
+        {
+            userDbModel.LandlordId = 1;
+            var landlordDbModel = new LandlordDbModel()
+            {
+                Id = 1,
+                FirstName = "John",
+                LastName = "Doe",
+                User = userDbModel
+            };
+        }
+        else
+        {
+            userDbModel.LandlordId = null;
+        }
+        return userDbModel;
+    }
+    
     protected BricksAndHeartsUser CreateUnregisteredUser()
     {
         var userDbModel = new UserDbModel()
@@ -35,6 +62,21 @@ public class ControllerTestsBase
 
         var unregisteredUser = new BricksAndHeartsUser(userDbModel, new List<Claim>(), "google");
         return unregisteredUser;
+    }
+    
+    protected BricksAndHeartsUser CreateNonAdminNonLandlordUser()
+    {
+        var userDbModel = new UserDbModel()
+        {
+            Id = 1,
+            GoogleUserName = "John Doe",
+            GoogleEmail = "test.email@gmail.com",
+            IsAdmin = false,
+            LandlordId = null
+        };
+
+        var nonAdminNonLandlordUser = new BricksAndHeartsUser(userDbModel, new List<Claim>(), "google");
+        return nonAdminNonLandlordUser;
     }
     
     protected BricksAndHeartsUser CreateAdminUser()

--- a/BricksAndHearts.UnitTests/ServiceTests/Admin/AdminServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Admin/AdminServiceTests.cs
@@ -128,21 +128,6 @@ public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
     }
     
     [Fact]
-    public void GetTenantList_GetsListOfTenants()
-    {
-        // Arrange
-        using var context = Fixture.CreateReadContext();
-        var service = new AdminService(context);
-
-        // Act
-        var result = service.GetTenantList().Result;
-
-        // Assert
-
-        result.Should().BeOfType<List<TenantDbModel>>().And.Subject.Should().HaveCount(context.Tenants.Count());
-    }
-
-    [Fact]
     public void GetLandlordDisplayList_CalledWithApproved_ReturnsApprovedLandlords()
     {
         // Arrange
@@ -184,6 +169,55 @@ public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
         
         // Assert
         result.Should().BeOfType<List<LandlordDbModel>>().And.Subject.Should().HaveCount(context.Landlords.Count());
+    }
+    
+    [Fact]
+    public void GetTenantList_GetsListOfTenants()
+    {
+        // Arrange
+        using var context = Fixture.CreateReadContext();
+        var service = new AdminService(context);
+
+        // Act
+        var result = service.GetTenantList().Result;
+
+        // Assert
+
+        result.Should().BeOfType<List<TenantDbModel>>().And.Subject.Should().HaveCount(context.Tenants.Count());
+    }
+    
+    [Fact]
+    public async void GetTenantDbModelsFromFilter_ReturnsFilteredTenantList_WithCorrectFilter()
+    {
+        // Arrange
+        await using var context = Fixture.CreateReadContext();
+        var service = new AdminService(context);
+        var filterArr = new [] { "single", "all", "true", "true", "all", "all"};
+
+        // Act
+        var result = await service.GetTenantDbModelsFromFilter(filterArr);
+
+        // Assert
+        result.Should().BeOfType<List<TenantDbModel>>();
+        result.Count.Should().Be(context.Tenants.Where(t => t.ETT == true)
+            .Where(t => t.UniversalCredit == true)
+            .Count(t => t.Type == "Single"));
+    }
+    
+    [Fact]
+    public async void GetTenantDbModelsFromFilter_ReturnsAllTenants_WithNoFilter()
+    {
+        // Arrange
+        await using var context = Fixture.CreateReadContext();
+        var service = new AdminService(context);
+        var filterArr = new string[]{"all","all","all","all","all","all"};
+
+        // Act
+        var result = await service.GetTenantDbModelsFromFilter(filterArr);
+
+        // Assert
+        result.Should().BeOfType<List<TenantDbModel>>();
+        result.Count.Should().Be(context.Tenants.Count());
     }
 
     [Fact]
@@ -285,39 +319,5 @@ public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
 
         // Assert
         service.Invoking(y => y.DeleteExistingInviteLink(1)).Should().Throw<Exception>();
-    }
-
-    [Fact]
-    public async void GetTenantDbModelsFromFilter_ReturnsFilteredTenantList_WithCorrectFilter()
-    {
-        // Arrange
-        await using var context = Fixture.CreateReadContext();
-        var service = new AdminService(context,null!);
-        var filterArr = new [] { "single", "all", "true", "true", "all", "all"};
-
-        // Act
-        var result = await service.GetTenantDbModelsFromFilter(filterArr);
-
-        // Assert
-        result.Should().BeOfType<List<TenantDbModel>>();
-        result.Count.Should().Be(context.Tenants.Where(t => t.ETT == true)
-                                                .Where(t => t.UniversalCredit == true)
-                                                .Count(t => t.Type == "Single"));
-    }
-    
-    [Fact]
-    public async void GetTenantDbModelsFromFilter_ReturnsAllTenants_WithNoFilter()
-    {
-        // Arrange
-        await using var context = Fixture.CreateReadContext();
-        var service = new AdminService(context,null!);
-        var filterArr = new string[]{"all","all","all","all","all","all"};
-
-        // Act
-        var result = await service.GetTenantDbModelsFromFilter(filterArr);
-
-        // Assert
-        result.Should().BeOfType<List<TenantDbModel>>();
-        result.Count.Should().Be(context.Tenants.Count());
     }
 }

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -67,14 +67,11 @@ public class AdminController : AbstractController
         if (user.IsAdmin)
         {
             LoggerAlreadyAdminWarning(_logger, user);
-
             return RedirectToAction(nameof(AdminDashboard));
         }
 
         _adminService.CancelAdminAccessRequest(user);
-
         FlashRequestSuccess(_logger, user, "cancelled admin access request");
-
         return RedirectToAction(nameof(AdminDashboard));
     }
     
@@ -90,13 +87,8 @@ public class AdminController : AbstractController
     [HttpPost]
     public ActionResult AcceptAdminRequest(int userToAcceptId)
     {
-        if (_adminService.GetUserFromId(userToAcceptId) == null)
-        {
-            return View("Error", new ErrorViewModel());
-        }
-
         _adminService.ApproveAdminAccessRequest(userToAcceptId);
-
+        _logger.LogInformation($"Admin request of user {userToAcceptId} approved by user {GetCurrentUser().Id}");
         return RedirectToAction("GetAdminList");
     }
 
@@ -104,13 +96,8 @@ public class AdminController : AbstractController
     [HttpPost]
     public ActionResult RejectAdminRequest(int userToRejectId)
     {
-        if (_adminService.GetUserFromId(userToRejectId) == null)
-        {
-            return View("Error", new ErrorViewModel());
-        }
-        
         _adminService.RejectAdminAccessRequest(userToRejectId);
-
+        _logger.LogInformation($"Admin request of user {userToRejectId} rejected by user {GetCurrentUser().Id}");
         return RedirectToAction("GetAdminList");
     }
 
@@ -146,7 +133,7 @@ public class AdminController : AbstractController
     public ActionResult GetInviteLink(int landlordId)
     {
         var user = _adminService.FindUserByLandlordId(landlordId);
-        if (user != null) // If landlord already linked to user
+        if (user != null)
         {
             var flashMessageBody = $"Landlord already linked to user {user.GoogleUserName}";
             FlashMessage(_logger, (flashMessageBody, "warning", flashMessageBody));
@@ -176,7 +163,7 @@ public class AdminController : AbstractController
     public ActionResult RenewInviteLink(int landlordId)
     {
         var user = _adminService.FindUserByLandlordId(landlordId);
-        if (user != null) // If landlord already linked to user
+        if (user != null)
         {
             TempData["InviteLinkMessage"] = $"Landlord already linked to user {user.GoogleUserName}";
         }

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -3,8 +3,6 @@
 using BricksAndHearts.Auth;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
-using LINQtoCSV;
-using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -127,6 +125,14 @@ public class AdminController : AbstractController
         tenantListModel.TenantList = await _adminService.GetTenantList();
         return View(tenantListModel);
     }
+    
+    [Authorize(Roles = "Admin")]
+    [HttpGet]
+    public async Task<IActionResult> GetFilteredTenants(TenantListModel tenantListModel)
+    {
+        tenantListModel.TenantList = await _adminService.GetTenantDbModelsFromFilter(tenantListModel.Filters);
+        return View("TenantList", tenantListModel);
+    }
 
     [Authorize(Roles = "Admin")]
     [HttpPost]
@@ -187,15 +193,7 @@ public class AdminController : AbstractController
 
         return RedirectToAction("Profile", "Landlord", new { id = landlordId });
     }
-    
-    [Authorize(Roles = "Admin")]
-    [HttpGet]
-    public async Task<IActionResult> GetFilteredTenants(TenantListModel tenantListModel)
-    {
-        tenantListModel.TenantList = await _adminService.GetTenantDbModelsFromFilter(tenantListModel.Filters);
-        return View("TenantList", tenantListModel);
-    }
-    
+
     [Authorize(Roles = "Admin")]
     [HttpPost]
     public ActionResult GetSampleTenantCSV()

--- a/web/Views/Admin/PropertyList.cshtml
+++ b/web/Views/Admin/PropertyList.cshtml
@@ -28,7 +28,8 @@
         <th scope="col">Description</th>
         <th scope="col">Availability</th>
         <th scope="col">Available From</th>
-        <th scope="col">Landlord's profile</th>
+        <th scope="col">Property page</th>
+        <th scope="col">Landlord profile</th>
     </tr>
     </thead>
     <tbody>
@@ -51,6 +52,11 @@
                 <td></td>
             }
             
+            <td>
+                <a type="button" class="btn btn-outline-primary" value="@property.PropertyId" href="@Url.Action("ViewProperty", "Property", new { id = property.PropertyId })">
+                    <i class="bi bi-house"></i>
+                </a>
+            </td>
             <td>
                 <a type="button" class="btn btn-outline-primary" value="@property.LandlordId" href="@Url.Action("Profile", "Landlord", new { id = property.LandlordId })">
                     <i class="bi bi-person"></i>

--- a/web/Views/Landlord/Properties.cshtml
+++ b/web/Views/Landlord/Properties.cshtml
@@ -38,8 +38,7 @@ else
     }
     @foreach (var prop in Model.Properties)
     {
-        <tr class="clickable"
-            onclick="location.href = '@Url.Action("ViewProperty", "Property", new { propertyId = prop!.PropertyId })'">
+        <tr>
             <th scope="row">@i</th>
             <td>
                 @prop.Address.AddressLine1,


### PR DESCRIPTION
I've added unit tests for all the endpoints in the Admin Controller. I've also done some minor refactoring in the Admin Controller, and to a lesser extent the Admin Service - this was primarily just changing the order in which the endpoints/methods appear, in order to group together ones which are to do with similar issues. I've been finding it increasingly difficult to work out if a relevant method already exists or not, since everything was a bit jumbled up - hopefully having re-ordered things slightly will make this easier for everyone.