### PR TITLE
BNH-63 - unassigned landlord list

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -180,12 +180,13 @@ public class AdminControllerTests : AdminControllerTestsBase
         // Arrange
         var adminUser = CreateAdminUser();
         MakeUserPrincipalInController(adminUser, UnderTest);
-
+        var landlordListModel = new LandlordListModel();
+        
         // Act
-        var result = await UnderTest.LandlordList() as ViewResult;
+        var result = await UnderTest.LandlordList(landlordListModel) as ViewResult;
 
         // Assert
-        A.CallTo(() => AdminService.GetLandlordList("")).MustHaveHappened();
+        A.CallTo(() => AdminService.GetLandlordList(landlordListModel.Filters)).MustHaveHappened();
         result!.ViewData.Model.Should().BeOfType<LandlordListModel?>();
     }
     
@@ -195,12 +196,13 @@ public class AdminControllerTests : AdminControllerTestsBase
         // Arrange
         var adminUser = CreateAdminUser();
         MakeUserPrincipalInController(adminUser, UnderTest);
+        var tenantListModel = new TenantListModel();
 
         // Act
-        var result = await UnderTest.TenantList() as ViewResult;
+        var result = await UnderTest.TenantList(tenantListModel) as ViewResult;
 
         // Assert
-        A.CallTo(() => AdminService.GetTenantList()).MustHaveHappened();
+        A.CallTo(() => AdminService.GetTenantList(tenantListModel.Filters)).MustHaveHappened();
         result!.ViewData.Model.Should().BeOfType<TenantListModel?>();
     }
     
@@ -270,7 +272,7 @@ public class AdminControllerTests : AdminControllerTestsBase
         UnderTest.TempData["FlashMessage"].Should().Be("Landlord already has an invite link: http:///invite/existing link");
     }
     
-        [Fact]
+    [Fact]
     public void RenewInviteLink_CalledOnLinkedLandlord_CallsFindUserByLandlordIdAndRedirectsToLandlordProfileWithFLash()
     {
         // Arrange
@@ -338,22 +340,6 @@ public class AdminControllerTests : AdminControllerTestsBase
         UnderTest.TempData["InviteLinkMessage"].Should().Be("Successfully created a new invite link :)");
     }
 
-    [Fact]
-    public void GetFilteredTenants_WithCorrectInput_CallsGetTenantDbModelsFromFilter()
-    {
-        // Arrange
-        MakeUserPrincipalInController(CreateAdminUser(), UnderTest);
-        var fakeTenantListModel = A.Fake<TenantListModel>();
-
-        // Act
-        A.CallTo(() => AdminService.GetTenantDbModelsFromFilter(fakeTenantListModel.Filters)).Returns(A.Fake<List<TenantDbModel>>());
-        var result = UnderTest.GetFilteredTenants(fakeTenantListModel).Result;
-        
-        // Assert
-        A.CallTo(() => AdminService.GetTenantDbModelsFromFilter(fakeTenantListModel.Filters)).MustHaveHappened();
-        result.Should().BeOfType<ViewResult>().Which.Model.Should().Be(fakeTenantListModel);
-    }
-    
     [Fact]
     public async void ImportTenants_WhenCalledWithEmptyFile_RedirectsToTenantListWithErrorFlashMessage()
     {

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -202,7 +202,7 @@ public class AdminControllerTests : AdminControllerTestsBase
         var result = await UnderTest.TenantList(tenantListModel) as ViewResult;
 
         // Assert
-        A.CallTo(() => AdminService.GetTenantList(tenantListModel.Filters)).MustHaveHappened();
+        A.CallTo(() => AdminService.GetTenantList(tenantListModel.Filter)).MustHaveHappened();
         result!.ViewData.Model.Should().BeOfType<TenantListModel?>();
     }
     

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -186,7 +186,7 @@ public class AdminControllerTests : AdminControllerTestsBase
         var result = await UnderTest.LandlordList(landlordListModel) as ViewResult;
 
         // Assert
-        A.CallTo(() => AdminService.GetLandlordList(landlordListModel.Filters)).MustHaveHappened();
+        A.CallTo(() => AdminService.GetLandlordList(landlordListModel)).MustHaveHappened();
         result!.ViewData.Model.Should().BeOfType<LandlordListModel?>();
     }
     

--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTests.cs
@@ -185,7 +185,7 @@ public class AdminControllerTests : AdminControllerTestsBase
         var result = await UnderTest.LandlordList() as ViewResult;
 
         // Assert
-        A.CallTo(() => AdminService.GetLandlordDisplayList("")).MustHaveHappened();
+        A.CallTo(() => AdminService.GetLandlordList("")).MustHaveHappened();
         result!.ViewData.Model.Should().BeOfType<LandlordListModel?>();
     }
     

--- a/BricksAndHearts.UnitTests/ServiceTests/Admin/AdminServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Admin/AdminServiceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BricksAndHearts.Auth;
 using BricksAndHearts.Database;
 using BricksAndHearts.Services;
+using BricksAndHearts.ViewModels;
 using FluentAssertions;
 using Xunit;
 
@@ -126,68 +127,58 @@ public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
         // Assert
         adminLists.CurrentAdmins.Should().OnlyContain(u => u.Id == adminUser.Id);
     }
-    
+
     [Fact]
-    public void GetLandlordDisplayList_CalledWithApproved_ReturnsApprovedLandlords()
+    public async void LandlordList_CalledWithNoFilter_ReturnsAllLandlords()
     {
         // Arrange
-        using var context = Fixture.CreateReadContext();
+        await using var context = Fixture.CreateReadContext();
         var service = new AdminService(context);
+        var landlordListModel = new LandlordListModel();
 
         // Act
-        var result = service.GetLandlordDisplayList("Approved").Result;
+        var result = await service.GetLandlordList(landlordListModel.Filters);
 
         // Assert
-        result.Should().BeOfType<List<LandlordDbModel>>().And.Subject.Where(u => u.CharterApproved).Should()
-            .HaveCount(result.Count);
+        result.Should().BeOfType<List<LandlordDbModel>>();
+        result.Count.Should().Be(context.Landlords.Count());
     }
     
     [Fact]
-    public void GetLandlordDisplayList_CalledWithUnapproved_ReturnsUnapprovedLandlords()
+    public async void LandlordList_CalledWithFilters_ReturnsCorrectlyFilteredLandlordList()
     {
         // Arrange
-        using var context = Fixture.CreateReadContext();
+        await using var context = Fixture.CreateReadContext();
         var service = new AdminService(context);
+        var filterArr = new [] { "Approved", "Unassigned" };
 
         // Act
-        var result = service.GetLandlordDisplayList("Unapproved").Result;
+        var result = await service.GetLandlordList(filterArr);
 
         // Assert
-        result.Should().BeOfType<List<LandlordDbModel>>().And.Subject.Where(u => u.CharterApproved == false).Should()
-            .HaveCount(result.Count);
+        result.Should().BeOfType<List<LandlordDbModel>>();
+        result.Count.Should().Be(context.Landlords.Where(l => l.CharterApproved == true)
+            .Count(l => context.Users.SingleOrDefault(u => u.LandlordId == l.Id) == null));
+    }
+
+    [Fact]
+    public async void TenantList_CalledWithNoFilter_ReturnsAllTenants()
+    {
+        // Arrange
+        await using var context = Fixture.CreateReadContext();
+        var service = new AdminService(context);
+        var tenantListModel = new TenantListModel();
+
+        // Act
+        var result = await service.GetTenantList(tenantListModel.Filters);
+
+        // Assert
+        result.Should().BeOfType<List<TenantDbModel>>();
+        result.Count.Should().Be(context.Tenants.Count());
     }
     
     [Fact]
-    public void GetLandlordDisplayList_CalledWithNothing_ReturnsAllLandlords()
-    {
-        // Arrange
-        using var context = Fixture.CreateReadContext();
-        var service = new AdminService(context);
-
-        // Act
-        var result = service.GetLandlordDisplayList("").Result;
-        
-        // Assert
-        result.Should().BeOfType<List<LandlordDbModel>>().And.Subject.Should().HaveCount(context.Landlords.Count());
-    }
-    
-    [Fact]
-    public void GetTenantList_GetsListOfTenants()
-    {
-        // Arrange
-        using var context = Fixture.CreateReadContext();
-        var service = new AdminService(context);
-
-        // Act
-        var result = service.GetTenantList().Result;
-
-        // Assert
-
-        result.Should().BeOfType<List<TenantDbModel>>().And.Subject.Should().HaveCount(context.Tenants.Count());
-    }
-    
-    [Fact]
-    public async void GetTenantDbModelsFromFilter_ReturnsFilteredTenantList_WithCorrectFilter()
+    public async void TenantList_CalledWithFilters_ReturnsCorrectlyFilteredTenantList()
     {
         // Arrange
         await using var context = Fixture.CreateReadContext();
@@ -195,29 +186,13 @@ public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
         var filterArr = new [] { "single", "all", "true", "true", "all", "all"};
 
         // Act
-        var result = await service.GetTenantDbModelsFromFilter(filterArr);
+        var result = await service.GetTenantList(filterArr);
 
         // Assert
         result.Should().BeOfType<List<TenantDbModel>>();
         result.Count.Should().Be(context.Tenants.Where(t => t.ETT == true)
             .Where(t => t.UniversalCredit == true)
             .Count(t => t.Type == "Single"));
-    }
-    
-    [Fact]
-    public async void GetTenantDbModelsFromFilter_ReturnsAllTenants_WithNoFilter()
-    {
-        // Arrange
-        await using var context = Fixture.CreateReadContext();
-        var service = new AdminService(context);
-        var filterArr = new string[]{"all","all","all","all","all","all"};
-
-        // Act
-        var result = await service.GetTenantDbModelsFromFilter(filterArr);
-
-        // Assert
-        result.Should().BeOfType<List<TenantDbModel>>();
-        result.Count.Should().Be(context.Tenants.Count());
     }
 
     [Fact]

--- a/BricksAndHearts.UnitTests/ServiceTests/Admin/AdminServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Admin/AdminServiceTests.cs
@@ -137,7 +137,7 @@ public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
         var landlordListModel = new LandlordListModel();
 
         // Act
-        var result = await service.GetLandlordList(landlordListModel.Filters);
+        var result = await service.GetLandlordList(landlordListModel);
 
         // Assert
         result.Should().BeOfType<List<LandlordDbModel>>();
@@ -150,10 +150,14 @@ public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
         // Arrange
         await using var context = Fixture.CreateReadContext();
         var service = new AdminService(context);
-        var filterArr = new [] { "Approved", "Unassigned" };
+        var landlordListModel = new LandlordListModel
+        {
+            Approved = true,
+            Assigned = false
+        };
 
         // Act
-        var result = await service.GetLandlordList(filterArr);
+        var result = await service.GetLandlordList(landlordListModel);
 
         // Assert
         result.Should().BeOfType<List<LandlordDbModel>>();

--- a/BricksAndHearts.UnitTests/ServiceTests/Admin/AdminServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Admin/AdminServiceTests.cs
@@ -152,8 +152,8 @@ public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
         var service = new AdminService(context);
         var landlordListModel = new LandlordListModel
         {
-            Approved = true,
-            Assigned = false
+            IsApproved = true,
+            IsAssigned = false
         };
 
         // Act
@@ -174,7 +174,7 @@ public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
         var tenantListModel = new TenantListModel();
 
         // Act
-        var result = await service.GetTenantList(tenantListModel.Filters);
+        var result = await service.GetTenantList(tenantListModel.Filter);
 
         // Assert
         result.Should().BeOfType<List<TenantDbModel>>();
@@ -187,10 +187,15 @@ public class AdminServiceTests : IClassFixture<TestDatabaseFixture>
         // Arrange
         await using var context = Fixture.CreateReadContext();
         var service = new AdminService(context);
-        var filterArr = new [] { "single", "all", "true", "true", "all", "all"};
+        var filter = new TenantListFilter
+        {
+            Type = "single",
+            ETT = true,
+            UniversalCredit = true
+        };
 
         // Act
-        var result = await service.GetTenantList(filterArr);
+        var result = await service.GetTenantList(filter);
 
         // Assert
         result.Should().BeOfType<List<TenantDbModel>>();

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -110,27 +110,17 @@ public class AdminController : AbstractController
 
     [Authorize(Roles = "Admin")]
     [HttpGet]
-    public async Task<IActionResult> LandlordList(string? approvalStatus = "")
+    public async Task<IActionResult> LandlordList(LandlordListModel landlordListModel)
     {
-        var landlordListModel = new LandlordListModel();
-        landlordListModel.LandlordDisplayList = await _adminService.GetLandlordDisplayList(approvalStatus!);
+        landlordListModel.LandlordList = await _adminService.GetLandlordList(landlordListModel.Filters);
         return View(landlordListModel);
     }
 
     [Authorize(Roles = "Admin")]
     [HttpGet]
-    public async Task<IActionResult> TenantList()
+    public async Task<IActionResult> TenantList(TenantListModel tenantListModel)
     {
-        var tenantListModel = new TenantListModel();
-        tenantListModel.TenantList = await _adminService.GetTenantList();
-        return View(tenantListModel);
-    }
-    
-    [Authorize(Roles = "Admin")]
-    [HttpGet]
-    public async Task<IActionResult> GetFilteredTenants(TenantListModel tenantListModel)
-    {
-        tenantListModel.TenantList = await _adminService.GetTenantDbModelsFromFilter(tenantListModel.Filters);
+        tenantListModel.TenantList = await _adminService.GetTenantList(tenantListModel.Filters);
         return View("TenantList", tenantListModel);
     }
 

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -112,7 +112,7 @@ public class AdminController : AbstractController
     [HttpGet]
     public async Task<IActionResult> LandlordList(LandlordListModel landlordListModel)
     {
-        landlordListModel.LandlordList = await _adminService.GetLandlordList(landlordListModel.Filters);
+        landlordListModel.LandlordList = await _adminService.GetLandlordList(landlordListModel);
         return View(landlordListModel);
     }
 

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -120,7 +120,7 @@ public class AdminController : AbstractController
     [HttpGet]
     public async Task<IActionResult> TenantList(TenantListModel tenantListModel)
     {
-        tenantListModel.TenantList = await _adminService.GetTenantList(tenantListModel.Filters);
+        tenantListModel.TenantList = await _adminService.GetTenantList(tenantListModel.Filter);
         return View("TenantList", tenantListModel);
     }
 

--- a/web/Migrations/BricksAndHeartsDbContextModelSnapshot.cs
+++ b/web/Migrations/BricksAndHeartsDbContextModelSnapshot.cs
@@ -67,6 +67,9 @@ namespace BricksAndHearts.Migrations
                     b.Property<string>("InviteLink")
                         .HasColumnType("nvarchar(max)");
 
+                    b.Property<bool>("IsAssigned")
+                        .HasColumnType("bit");
+
                     b.Property<bool>("IsLandlordForProfit")
                         .HasColumnType("bit");
 

--- a/web/Migrations/BricksAndHeartsDbContextModelSnapshot.cs
+++ b/web/Migrations/BricksAndHeartsDbContextModelSnapshot.cs
@@ -67,9 +67,6 @@ namespace BricksAndHearts.Migrations
                     b.Property<string>("InviteLink")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("IsAssigned")
-                        .HasColumnType("bit");
-
                     b.Property<bool>("IsLandlordForProfit")
                         .HasColumnType("bit");
 

--- a/web/Services/AdminService.cs
+++ b/web/Services/AdminService.cs
@@ -16,9 +16,8 @@ public interface IAdminService
     
     //Information Lists
     public Task<(List<UserDbModel> CurrentAdmins, List<UserDbModel> PendingAdmins)> GetAdminLists();
-    public Task<List<LandlordDbModel>> GetLandlordDisplayList(string approvalStatus);
-    public Task<List<TenantDbModel>> GetTenantList();
-    public Task<List<TenantDbModel>> GetTenantDbModelsFromFilter(string[] filterArray);
+    public Task<List<LandlordDbModel>> GetLandlordList(string[] filterArray);
+    public Task<List<TenantDbModel>> GetTenantList(string[] filterArray);
     
     //Invite Links
     public UserDbModel? FindUserByLandlordId(int landlordId);
@@ -98,22 +97,33 @@ public class AdminService : IAdminService
         return pendingAdmins;
     }
 
-    public async Task<List<LandlordDbModel>> GetLandlordDisplayList(string approvalStatus)
+    public async Task<List<LandlordDbModel>> GetLandlordList(string[] filterArray)
     {
-        return approvalStatus switch
+        var landlordQuery = from landlords in _dbContext.Landlords select landlords;
+        for (var currentFilterNo = 0; currentFilterNo < filterArray.Length; currentFilterNo++)
         {
-            "Unapproved" => await _dbContext.Landlords.Where(u => u.CharterApproved == false).ToListAsync(),
-            "Approved" => await _dbContext.Landlords.Where(u => u.CharterApproved == true).ToListAsync(),
-            _ => await _dbContext.Landlords.ToListAsync(),
-        };
+            var filterToCheck = filterArray[currentFilterNo];
+            landlordQuery = currentFilterNo switch
+            {
+                0 => filterToCheck switch
+                {
+                    "Approved" => landlordQuery.Where(l => l.CharterApproved == true),
+                    "Unapproved" => landlordQuery.Where(l => l.CharterApproved == false),
+                    _ => landlordQuery
+                },
+                1 => filterToCheck switch
+                {
+                    "Assigned" => landlordQuery.Where(l => _dbContext.Users.SingleOrDefault(u => u.LandlordId == l.Id) != null),
+                    "Unassigned" => landlordQuery.Where(l => _dbContext.Users.SingleOrDefault(u => u.LandlordId == l.Id) == null),
+                    _ => landlordQuery
+                },
+                _ => landlordQuery
+            };
+        }
+        return await landlordQuery.ToListAsync();
     }
     
-    public async Task<List<TenantDbModel>> GetTenantList()
-    {
-        return await _dbContext.Tenants.ToListAsync();
-    }
-    
-    public async Task<List<TenantDbModel>> GetTenantDbModelsFromFilter(string[] filterArray)
+    public async Task<List<TenantDbModel>> GetTenantList(string[] filterArray)
     {
         var tenantQuery = from tenants in _dbContext.Tenants select tenants;
         for (var currentFilterNo = 0; currentFilterNo < filterArray.Length; currentFilterNo++)

--- a/web/ViewModels/LandlordListModel.cs
+++ b/web/ViewModels/LandlordListModel.cs
@@ -3,5 +3,6 @@ namespace BricksAndHearts.ViewModels;
 
 public class LandlordListModel
 {
-    public List<LandlordDbModel>? LandlordDisplayList { get; set; }
+    public List<LandlordDbModel>? LandlordList { get; set; }
+    public string[] Filters { get; set; } = new string[2];
 }

--- a/web/ViewModels/LandlordListModel.cs
+++ b/web/ViewModels/LandlordListModel.cs
@@ -4,5 +4,6 @@ namespace BricksAndHearts.ViewModels;
 public class LandlordListModel
 {
     public List<LandlordDbModel>? LandlordList { get; set; }
-    public string[] Filters { get; set; } = new string[2];
+    public bool? Approved { get; set; }
+    public bool? Assigned { get; set; }
 }

--- a/web/ViewModels/LandlordListModel.cs
+++ b/web/ViewModels/LandlordListModel.cs
@@ -4,6 +4,6 @@ namespace BricksAndHearts.ViewModels;
 public class LandlordListModel
 {
     public List<LandlordDbModel>? LandlordList { get; set; }
-    public bool? Approved { get; set; }
-    public bool? Assigned { get; set; }
+    public bool? IsApproved { get; set; }
+    public bool? IsAssigned { get; set; }
 }

--- a/web/ViewModels/TenantListFilter.cs
+++ b/web/ViewModels/TenantListFilter.cs
@@ -1,0 +1,11 @@
+﻿namespace BricksAndHearts.ViewModels;
+
+public class TenantListFilter
+{
+    public string Type { get; set; } = "";
+    public bool? HasPet { get; set; }
+    public bool? ETT { get; set; }
+    public bool? UniversalCredit { get; set; }
+    public bool? HousingBenefits { get; set; }
+    public bool? Over35 { get; set; }
+}

--- a/web/ViewModels/TenantListModel.cs
+++ b/web/ViewModels/TenantListModel.cs
@@ -5,5 +5,5 @@ public class TenantListModel
 {
     public List<TenantDbModel>? TenantList { get; set; }
 
-    public string[] Filters { get; set; } = new string[6];
+    public string[] Filters { get; set; } = new string[6]{"all", "all", "all", "all", "all", "all"};
 }

--- a/web/ViewModels/TenantListModel.cs
+++ b/web/ViewModels/TenantListModel.cs
@@ -5,5 +5,5 @@ public class TenantListModel
 {
     public List<TenantDbModel>? TenantList { get; set; }
 
-    public string[] Filters { get; set; } = new string[6]{"all", "all", "all", "all", "all", "all"};
+    public TenantListFilter Filter { get; set; } = new TenantListFilter();
 }

--- a/web/Views/Admin/LandlordList.cshtml
+++ b/web/Views/Admin/LandlordList.cshtml
@@ -13,17 +13,17 @@
 {
     <div class="row g-3">
         <div class="col-auto d-grid">
-            <select class="form-select" id="Filters[0]" name="Filters[0]">
+            <select class="form-select" id="Approved" name="Approved">
                 <option selected>Filter by approval status</option>
-                <option value="Approved">Display approved landlords</option>
-                <option value="Unapproved">Display unapproved landlords</option>
+                <option value="true">Display approved landlords</option>
+                <option value="false">Display unapproved landlords</option>
             </select>
         </div>
         <div class="col-auto d-grid">
-            <select class="form-select" id="Filters[1]" name="Filters[1]">
+            <select class="form-select" id="Assigned" name="Assigned">
                 <option selected>Filter by assignment status</option>
-                <option value="Assigned">Display assigned landlords</option>
-                <option value="Unassigned">Display unassigned landlords</option>
+                <option value="true">Display assigned landlords</option>
+                <option value="false">Display unassigned landlords</option>
             </select>
         </div>
         <div class="col-auto d-grid">

--- a/web/Views/Admin/LandlordList.cshtml
+++ b/web/Views/Admin/LandlordList.cshtml
@@ -12,19 +12,30 @@
 @using (Html.BeginForm("LandlordList", "Admin", FormMethod.Get))
 {
     <div class="row g-3">
+
         <div class="col-auto d-grid">
-            <select class="form-select" id="Approved" name="Approved">
-                <option selected>Filter by approval status</option>
-                <option value="true">Display approved landlords</option>
-                <option value="false">Display unapproved landlords</option>
-            </select>
+            @Html.DropDownListFor(
+                model => model.IsApproved,
+                new List<SelectListItem>
+                {
+                    new("Display approved landlords", "true"),
+                    new("Display unapproved landlords", "false")
+                }, 
+                "Filter by approval status",
+                new { @class="form-select" }
+                )
         </div>
         <div class="col-auto d-grid">
-            <select class="form-select" id="Assigned" name="Assigned">
-                <option selected>Filter by assignment status</option>
-                <option value="true">Display assigned landlords</option>
-                <option value="false">Display unassigned landlords</option>
-            </select>
+            @Html.DropDownListFor(
+                model => model.IsAssigned,
+                new List<SelectListItem>
+                {
+                    new("Display assigned landlords", "true"),
+                    new("Display unassigned landlords", "false")
+                }, 
+                "Filter by assignment status",
+                new { @class="form-select" }
+                )
         </div>
         <div class="col-auto d-grid">
             <button type="submit" class="btn btn-primary">Display results</button>

--- a/web/Views/Admin/LandlordList.cshtml
+++ b/web/Views/Admin/LandlordList.cshtml
@@ -6,18 +6,32 @@
 
 <h2>Landlord List</h2>
 
-<div class="mb-3">
-    @using (Html.BeginForm("LandlordList", "Admin", FormMethod.Get))
-    {
-        <select class="form-select" id="approvalStatus" name="approvalStatus">
-            <option disabled selected>Filter by approval status</option>
-            <option value="">Display all landlords</option>
-            <option value="Unapproved">Display unapproved landlords</option>
-            <option value="Approved">Display approved landlords</option>
-        </select>
-        <button type="submit" class="btn custom-btn-primary">Display results</button>
-    }
-</div>
+<a class="btn btn-primary" asp-controller="Landlord" asp-action="RegisterGet" asp-route-createUnassigned="true">Create Unassigned Landlord</a> <br/>
+
+<p></p>
+@using (Html.BeginForm("LandlordList", "Admin", FormMethod.Get))
+{
+    <div class="row g-3">
+        <div class="col-auto d-grid">
+            <select class="form-select" id="Filters[0]" name="Filters[0]">
+                <option selected>Filter by approval status</option>
+                <option value="Approved">Display approved landlords</option>
+                <option value="Unapproved">Display unapproved landlords</option>
+            </select>
+        </div>
+        <div class="col-auto d-grid">
+            <select class="form-select" id="Filters[1]" name="Filters[1]">
+                <option selected>Filter by assignment status</option>
+                <option value="Assigned">Display assigned landlords</option>
+                <option value="Unassigned">Display unassigned landlords</option>
+            </select>
+        </div>
+        <div class="col-auto d-grid">
+            <button type="submit" class="btn btn-primary">Display results</button>
+        </div>
+    </div>
+}
+<p></p>
 
 <table class="table">
     <thead>
@@ -32,7 +46,7 @@
     </tr>
     </thead>
     <tbody>
-    @foreach (var landlord in Model.LandlordDisplayList!)
+    @foreach (var landlord in Model.LandlordList!)
     {
         <tr>
             <td>@landlord.FirstName</td>

--- a/web/Views/Admin/TenantList.cshtml
+++ b/web/Views/Admin/TenantList.cshtml
@@ -20,7 +20,7 @@
 
 <h2>Tenant List</h2>
 
-<form method="get" asp-controller="Admin" asp-action="GetFilteredTenants">
+<form method="get" asp-controller="Admin" asp-action="TenantList">
 
     <div class="row g-3">
         <div class="col-auto d-grid">

--- a/web/Views/Admin/TenantList.cshtml
+++ b/web/Views/Admin/TenantList.cshtml
@@ -24,56 +24,79 @@
 
     <div class="row g-3">
         <div class="col-auto d-grid">
-            <label asp-for="Filters[0]" class="form-label">Tenant type</label>
-            <select asp-for="Filters[0]" class="form-select">
-                <option value="all">All</option>
-                <option value="Single">Single tenant</option>
-                <option value="Couple">Couple</option>
-                <option value="Family">Family</option>
-            </select>
+            @Html.DropDownListFor(
+                model => model.Filter.Type,
+                new List<SelectListItem>
+                {
+                    new("Single", "Single"),
+                    new("Couple", "Couple"),
+                    new("Family", "Family")
+                }, 
+                "Filter by Tenant Type",
+                new { @class="form-select" }
+                )
         </div>
         <div class="col-auto d-grid">
-            <label asp-for="Filters[1]" class="form-label">Has pet</label>
-            <select asp-for="Filters[1]" class="form-select">
-                <option value="all">All</option>
-                <option value="true">Yes</option>
-                <option value="false">No</option>
-            </select>
+            @Html.DropDownListFor(
+                model => model.Filter.HasPet,
+                new List<SelectListItem>
+                {
+                    new("Has pet", "true"),
+                    new("Does not have pet", "false")
+                }, 
+                "Filter by Pets",
+                new { @class="form-select" }
+                )
         </div>
         <div class="col-auto d-grid">
-            <label asp-for="Filters[2]" class="form-label">In ETT</label>
-            <select asp-for="Filters[2]" class="form-select">
-                <option value="all">All</option>
-                <option value="true">Yes</option>
-                <option value="false">No</option>
-            </select>
+            @Html.DropDownListFor(
+                model => model.Filter.ETT,
+                new List<SelectListItem>
+                {
+                    new("In ETT", "true"),
+                    new("Not in ETT", "false")
+                }, 
+                "Filter by ETT",
+                new { @class="form-select" }
+                )
         </div>
         <div class="col-auto d-grid">
-            <label asp-for="Filters[3]" class="form-label">On universal credit</label>
-            <select asp-for="Filters[3]" class="form-select">
-                <option value="all">All</option>
-                <option value="true">Yes</option>
-                <option value="false">No</option>
-            </select>
+            @Html.DropDownListFor(
+                model => model.Filter.UniversalCredit,
+                new List<SelectListItem>
+                {
+                    new("On Universal Credit", "true"),
+                    new("Not on Universal Credit", "false")
+                }, 
+                "Filter by Universal Credit",
+                new { @class="form-select" }
+                )
         </div>
         <div class="col-auto d-grid">
-            <label asp-for="Filters[4]" class="form-label">On benefits</label>
-            <select asp-for="Filters[4]" class="form-select">
-                <option value="all">All</option>
-                <option value="true">Yes</option>
-                <option value="false">No</option>
-            </select>
+            @Html.DropDownListFor(
+                model => model.Filter.HousingBenefits,
+                new List<SelectListItem>
+                {
+                    new("On Housing Benefits", "true"),
+                    new("Not on Housing Benefits", "false")
+                }, 
+                "Filter by Housing Benefits",
+                new { @class="form-select" }
+                )
         </div>
         <div class="col-auto d-grid">
-            <label asp-for="Filters[5]" class="form-label">Over 35</label>
-            <select asp-for="Filters[5]" class="form-select">
-                <option value="all">All</option>
-                <option value="true">Yes</option>
-                <option value="false">No</option>
-            </select>
+            @Html.DropDownListFor(
+                model => model.Filter.Over35,
+                new List<SelectListItem>
+                {
+                    new("Over 35", "true"),
+                    new("35 or under", "false")
+                }, 
+                "Filter by Over 35",
+                new { @class="form-select" }
+                )
         </div>
     </div>
-    
     <input type="submit" value="Filter" class="btn btn-large btn-primary mb-3"/>
 </form>
 


### PR DESCRIPTION
Added filters to the Landlord List so that admins can filter the list by assigned/unassigned, as well as by approved/unapproved. In the process of doing so, I discovered a mostly redundant endpoint for the TenantList, so I've changed this slightly.

Also added a button to the Landlord List for admins to Create Unassigned Landlords.