### PR TITLE
BNH-97 fix: Return View instead of 404 when invalid model for edit

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
@@ -205,7 +205,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
     }
 
     [Fact]
-    public void EditProfileUpdate_CalledUsingInvalidModel_Returns404Error()
+    public void EditProfileUpdate_CalledUsingInvalidModel_ReturnsEditPageView()
     {
         // Arrange
         var landlordUser = CreateLandlordUser();
@@ -214,10 +214,12 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         var invalidLandlordModel = CreateInvalidLandlordProfileModel();
 
         // Act
-        var result = UnderTest.EditProfileUpdate(invalidLandlordModel).Result;
+        var result = UnderTest.EditProfileUpdate(invalidLandlordModel).Result as ViewResult;
 
-        // Assert   
-        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(404);
+        // Assert
+        result!.Model.Should().BeOfType<LandlordProfileModel>();
+        result.Should().BeOfType<ViewResult>().Which.ViewName.Should().BeEquivalentTo("EditProfilePage");
+        UnderTest.ModelState.IsValid.Should().BeFalse();
     }
 
     [Fact]

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -237,7 +237,7 @@ public class LandlordController : AbstractController
         var user = GetCurrentUser();
         if (!ModelState.IsValid || !TryValidateModel(editModel.Address, nameof(AddressModel)))
         {
-            return StatusCode(404);
+            return View("EditProfilePage", editModel);
         }
 
         if (user.LandlordId != editModel.LandlordId && !user.IsAdmin)


### PR DESCRIPTION
If `ModelState` is not valid when editing a landlord, we now return to the form instead of resulting in a 404.