### PR TITLE
BNH-114 fix: Clear membership ID field

### DIFF
--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -261,6 +261,12 @@ public class LandlordController : AbstractController
             return View("EditProfilePage", editModel);
         }
 
+        if (editModel.MembershipId == null)
+        {
+            // If membership ID is removed, also unapprove charter
+            await _landlordService.UnapproveLandlord(editModel.LandlordId!.Value);
+        }
+
         await _landlordService.EditLandlordDetails(editModel);
         _logger.LogInformation("Successfully edited landlord for landlord {LandlordId}", editModel.LandlordId);
         return RedirectToAction("Profile", new { id = editModel.LandlordId });

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -46,6 +46,7 @@ public interface ILandlordService
     public bool CheckForDuplicateEmail(LandlordProfileModel editModel);
     public bool CheckForDuplicateMembershipId(LandlordProfileModel editModel);
     public Task<ApproveLandlordResult> ApproveLandlord(int landlordId, BricksAndHeartsUser user, string membershipId);
+    public Task UnapproveLandlord(int landlordId);
     public LandlordDbModel? FindLandlordWithInviteLink(string inviteLink);
 
     public Task<LinkUserWithLandlordResult> LinkExistingLandlordWithUser(
@@ -216,6 +217,21 @@ public class LandlordService : ILandlordService
 
         await _dbContext.SaveChangesAsync();
         return ILandlordService.ApproveLandlordResult.Success;
+    }
+
+    public async Task UnapproveLandlord(int landlordId)
+    {
+        var landlord = await GetLandlordIfExistsFromId(landlordId);
+        if (landlord is null)
+        {
+            return;
+        }
+
+        landlord.CharterApproved = false;
+        landlord.ApprovalTime = null;
+        landlord.ApprovalAdminId = null;
+
+        await _dbContext.SaveChangesAsync();
     }
 
     public LandlordDbModel? FindLandlordWithInviteLink(string inviteLink)

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -221,11 +221,7 @@ public class LandlordService : ILandlordService
 
     public async Task UnapproveLandlord(int landlordId)
     {
-        var landlord = await GetLandlordIfExistsFromId(landlordId);
-        if (landlord is null)
-        {
-            return;
-        }
+        var landlord = _dbContext.Landlords.Single(l => l.Id == landlordId);
 
         landlord.CharterApproved = false;
         landlord.ApprovalTime = null;

--- a/web/Views/Landlord/_RegisterPagePartial.cshtml
+++ b/web/Views/Landlord/_RegisterPagePartial.cshtml
@@ -103,7 +103,7 @@
             <div class="form-group my-3">
                 <label for="Select" class="form-label">Charter status</label>
                 <select class="form-select" required
-                        id="Select" onclick="checkIfSelectedValueIsTarget('true')">
+                        id="Select" onclick="checkIfSelectedValueIsTarget('true'); clearMembershipIdIfFalse()">
                     <!option @(Model.MembershipId != null ? "selected" : "") value="true">Already approved</!option>
                     <!option @(Model.MembershipId == null ? "selected" : "") value="false">Not yet approved</!option>
                 </select>

--- a/web/Views/Landlord/_RegisterPagePartial.cshtml
+++ b/web/Views/Landlord/_RegisterPagePartial.cshtml
@@ -103,7 +103,7 @@
             <div class="form-group my-3">
                 <label for="Select" class="form-label">Charter status</label>
                 <select class="form-select" required
-                        id="Select" onclick="checkIfSelectedValueIsTarget('true'); clearMembershipIdIfFalse()">
+                        id="Select" onchange="checkIfSelectedValueIsTarget('true'); clearMembershipIdIfFalse()">
                     <!option @(Model.MembershipId != null ? "selected" : "") value="true">Already approved</!option>
                     <!option @(Model.MembershipId == null ? "selected" : "") value="false">Not yet approved</!option>
                 </select>

--- a/web/wwwroot/js/site.js
+++ b/web/wwwroot/js/site.js
@@ -17,14 +17,20 @@ function checkIfSelectedValueIsTarget(target){
     }
 }
 
-function copyLinkToClipboard(linkToCopy){
+function clearMembershipIdIfFalse() {
+    if ($("#Select :selected").val() == "false") {
+        $("#MembershipId").val(null);
+    }
+}
+
+function copyLinkToClipboard(linkToCopy) {
     // Copy the text passed into the function plus the rest of the url
-    const fullLink = window.location.origin+"/invite/"+linkToCopy
+    const fullLink = window.location.origin + "/invite/" + linkToCopy
     navigator.clipboard.writeText(fullLink)
-    .then(() => {
-        // Change the button styling to show the link has been copied
-        const copyBtn = document.getElementById("copyBtn");
-        copyBtn.innerHTML = "<i class='bi bi-check'></i> invite link copied"
-        copyBtn.className = "btn btn-success my-3"
-    });
+        .then(() => {
+            // Change the button styling to show the link has been copied
+            const copyBtn = document.getElementById("copyBtn");
+            copyBtn.innerHTML = "<i class='bi bi-check'></i> invite link copied"
+            copyBtn.className = "btn btn-success my-3"
+        });
 }


### PR DESCRIPTION
When editing a landlord, if the charter status is changed from "Already approved" to "Not yet approved" we clear the membership ID input (which is hidden at this point).
Additionally, when a landlord is edited and the membership ID is set to null (or is already null), we un-approve the landlord's charter.