### PR TITLE
BNH 143: Simple matching algorithm

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
@@ -16,6 +16,7 @@ public class AdminControllerTestsBase : ControllerTestsBase
     protected readonly ILandlordService LandlordService;
     protected readonly IPropertyService PropertyService;
     protected readonly ICsvImportService CsvImportService;
+    protected readonly IMailService MailService;
     protected IEnumerable<string>? FlashMessages => UnderTest.TempData["FlashMessages"] as List<string>;
     protected readonly AdminController UnderTest;
 
@@ -26,9 +27,10 @@ public class AdminControllerTestsBase : ControllerTestsBase
         LandlordService = A.Fake<ILandlordService>();
         PropertyService = A.Fake<IPropertyService>();
         CsvImportService = A.Fake<ICsvImportService>();
+        MailService = A.Fake<IMailService>();
         var httpContext = new DefaultHttpContext();
         var tempData = new TempDataDictionary(httpContext, A.Fake<ITempDataProvider>());
-        UnderTest = new AdminController(Logger, AdminService, LandlordService, PropertyService, CsvImportService){TempData = tempData};
+        UnderTest = new AdminController(Logger, AdminService, LandlordService, PropertyService, CsvImportService, MailService){TempData = tempData};
     }
 
     protected IFormFile CreateExampleFile(string fileName, int length)

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandLordControllerUnassignedTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandLordControllerUnassignedTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using BricksAndHearts.Database;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
@@ -37,7 +38,7 @@ public class LandLordControllerUnassignedTests : LandlordControllerTestsBase
         A.CallTo(() => LandlordService.RegisterLandlord(formResultModel))
             .Returns((ILandlordService.LandlordRegistrationResult.Success, returnedLandlord));
         A.CallTo(() => MailService.SendMsg(
-            A<string>.That.Matches(s => s == msgBody), A<string>.That.Matches(s => s == subject), A<string>.Ignored,
+            A<string>.That.Matches(s => s == msgBody), A<string>.That.Matches(s => s == subject), A<List<string>>.Ignored, A<string>.Ignored,
             A<string>.Ignored
         )).WithAnyArguments().DoesNothing();
 
@@ -46,7 +47,7 @@ public class LandLordControllerUnassignedTests : LandlordControllerTestsBase
 
         // Assert
         A.CallTo(() => MailService.TrySendMsgInBackground(
-            A<string>.That.Matches(s => s == msgBody), A<string>.That.Matches(s => s == subject)
+            A<string>.That.Matches(s => s == msgBody), A<string>.That.Matches(s => s == subject), null
         )).WithAnyArguments().MustHaveHappened();
         A.CallTo(() => LandlordService.RegisterLandlord(formResultModel)).MustHaveHappened();
         result.Should().BeOfType<RedirectToActionResult>();
@@ -70,19 +71,16 @@ public class LandLordControllerUnassignedTests : LandlordControllerTestsBase
         A.CallTo(() => LandlordService.RegisterLandlord(formResultModel))
             .Returns((ILandlordService.LandlordRegistrationResult.Success, returnedLandlord));
         A.CallTo(() => MailService.SendMsg(
-            A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, A<string>.Ignored
+            A<string>.Ignored, A<string>.Ignored, A<List<string>>.Ignored,A<string>.Ignored, A<string>.Ignored
         )).WithAnyArguments().DoesNothing();
         var result = await UnderTest.RegisterPost(formResultModel) as StatusCodeResult;
 
         // Assert
         A.CallTo(() => LandlordService.RegisterLandlord(formResultModel)).WithAnyArguments().MustNotHaveHappened();
         A.CallTo(() => MailService.SendMsg(
-            A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, A<string>.Ignored
+            A<string>.Ignored, A<string>.Ignored, A<List<string>>.Ignored,A<string>.Ignored, A<string>.Ignored
         )).WithAnyArguments().MustNotHaveHappened();
         result.Should().NotBeNull();
-        if (result != null)
-        {
-            result.StatusCode.Should().Be(403);
-        }
+        result?.StatusCode.Should().Be(403);
     }
 }

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -5,7 +5,6 @@ using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 
 #endregion
 
@@ -20,8 +19,13 @@ public class AdminController : AbstractController
     private readonly ILogger<AdminController> _logger;
     private readonly IMailService _mailService;
 
-    public AdminController(ILogger<AdminController> logger, IAdminService adminService,
-        ILandlordService landlordService, IPropertyService propertyService, ICsvImportService csvImportService, IMailService mailService)
+    public AdminController(
+        ILogger<AdminController> logger,
+        IAdminService adminService,
+        ILandlordService landlordService,
+        IPropertyService propertyService, 
+        ICsvImportService csvImportService, 
+        IMailService mailService)
     {
         _logger = logger;
         _adminService = adminService;
@@ -31,8 +35,7 @@ public class AdminController : AbstractController
         _mailService = mailService;
     }
 
-    [HttpGet]
-    [Route("/admin")]
+    [HttpGet("/admin")]
     public IActionResult AdminDashboard()
     {
         var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
@@ -145,8 +148,7 @@ public class AdminController : AbstractController
     }
     
     [Authorize(Roles = "Admin")]
-    [HttpGet]
-    [Route("{currentPropertyId:int}/Matches")]
+    [HttpGet("{currentPropertyId:int}/Matches")]
     public async Task<IActionResult> TenantMatchList(int currentPropertyId)
     {
         var currentProperty = PropertyViewModel.FromDbModel(_propertyService.GetPropertyByPropertyId(currentPropertyId)!);
@@ -159,8 +161,7 @@ public class AdminController : AbstractController
     }
 
     [Authorize(Roles = "Admin")]
-    [HttpPost]
-    [Route("{currentPropertyId:int}/Matches")]
+    [HttpPost("{currentPropertyId:int}/Matches")]
     public ActionResult SendMatchLinkEmail(string propertyLink, string tenantEmail, int currentPropertyId)
     {
         var addressToSendTo = new List<string> { tenantEmail };

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -160,6 +160,18 @@ public class AdminController : AbstractController
 
     [Authorize(Roles = "Admin")]
     [HttpPost]
+    [Route("{currentPropertyId:int}/Matches")]
+    public ActionResult SendMatchLinkEmail(string propertyLink, string tenantEmail, int currentPropertyId)
+    {
+        var addressToSendTo = new List<string> { tenantEmail };
+        _mailService.TrySendMsgInBackground(propertyLink, tenantEmail, addressToSendTo);
+        _logger.LogInformation($"Successfully emailed tenant {tenantEmail}");
+        AddFlashMessage("success", $"successfully emailed {tenantEmail}");
+        return RedirectToAction("TenantMatchList", new {currentPropertyId});
+    }
+    
+    [Authorize(Roles = "Admin")]
+    [HttpPost]
     public ActionResult GetInviteLink(int landlordId)
     {
         var user = _adminService.FindUserByLandlordId(landlordId);
@@ -276,16 +288,5 @@ public class AdminController : AbstractController
             AddFlashMessage("success", "Successfully imported all tenant data.");
         }
         return RedirectToAction(nameof(TenantList));
-    }
-
-    [Authorize(Roles = "Admin")]
-    [HttpPost]
-    [Route("{currentPropertyId:int}/Matches")]
-    public ActionResult SendMatchLinkEmail(string propertyLink, string tenantEmail, int currentPropertyId)
-    {
-        var addressToSendTo = new List<string> { tenantEmail };
-        _mailService.TrySendMsgInBackground(propertyLink, tenantEmail, addressToSendTo);
-        FlashMessage(_logger, ("Successfully emailed tenant", "success", $"successfully emailed {tenantEmail}"));
-        return RedirectToAction(nameof(TenantMatchList), new {currentPropertyId});
     }
 }

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -140,6 +140,20 @@ public class AdminController : AbstractController
         tenantListModel.TenantList = await _adminService.GetTenantList(tenantListModel.Filter);
         return View("TenantList", tenantListModel);
     }
+    
+    [Authorize(Roles = "Admin")]
+    [HttpGet]
+    [Route("{currentPropertyId:int}/Matches")]
+    public async Task<IActionResult> TenantMatchList(int currentPropertyId)
+    {
+        var currentProperty = PropertyViewModel.FromDbModel(_propertyService.GetPropertyByPropertyId(currentPropertyId)!);
+        
+        var tenantMatchListModel = new TenantMatchListModel{
+            TenantList = await _adminService.GetNearestTenantsToProperty(currentProperty),
+            CurrentProperty = currentProperty
+        };
+        return View("TenantMatchList", tenantMatchListModel);
+    }
 
     [Authorize(Roles = "Admin")]
     [HttpPost]

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -86,7 +86,7 @@ public class LandlordController : AbstractController
                               + $"Email: {createModel.Email}" + "\n"
                               + $"Phone: {createModel.Phone}" + "\n";
                 var subject = "Bricks&Hearts - landlord registration notification";
-                _mailService.TrySendMsgInBackground(msgBody, subject);
+                _mailService.TrySendMsgInBackground(msgBody, subject, null);
                 return RedirectToAction("Profile", "Landlord", new { landlord!.Id });
 
             case ILandlordService.LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered:

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -86,7 +86,7 @@ public class LandlordController : AbstractController
                               + $"Email: {createModel.Email}" + "\n"
                               + $"Phone: {createModel.Phone}" + "\n";
                 var subject = "Bricks&Hearts - landlord registration notification";
-                _mailService.TrySendMsgInBackground(msgBody, subject, null);
+                _mailService.TrySendMsgInBackground(msgBody, subject);
                 return RedirectToAction("Profile", "Landlord", new { landlord!.Id });
 
             case ILandlordService.LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered:

--- a/web/ViewModels/TenantMatchListModel.cs
+++ b/web/ViewModels/TenantMatchListModel.cs
@@ -4,5 +4,5 @@ namespace BricksAndHearts.ViewModels;
 public class TenantMatchListModel
 {
     public List<TenantDbModel>? TenantList { get; set; }
-    public PropertyViewModel CurrentProperty { get; set; } = null!;
+    public PropertyViewModel CurrentProperty { get; set; } = new();
 }

--- a/web/ViewModels/TenantMatchListModel.cs
+++ b/web/ViewModels/TenantMatchListModel.cs
@@ -1,0 +1,8 @@
+﻿using BricksAndHearts.Database;
+namespace BricksAndHearts.ViewModels;
+
+public class TenantMatchListModel
+{
+    public List<TenantDbModel>? TenantList { get; set; }
+    public PropertyViewModel CurrentProperty { get; set; } = null!;
+}

--- a/web/Views/Admin/PropertyList.cshtml
+++ b/web/Views/Admin/PropertyList.cshtml
@@ -41,6 +41,7 @@
         <th scope="col">Available From</th>
         <th scope="col">Landlord's profile</th>
         <th scope="col">Property information</th>
+        <th scope="col">Matches</th>
     </tr>
     </thead>
     <tbody>
@@ -79,6 +80,10 @@
                         </span>
                     }
                 </a>
+            </td>
+            <td>
+                @Html.ActionLink("View matches", "TenantMatchList", "Admin", new { currentPropertyId = property.PropertyId}, 
+                            new { @class = "btn btn-primary" })
             </td>
         </tr>
     }

--- a/web/Views/Admin/TenantList.cshtml
+++ b/web/Views/Admin/TenantList.cshtml
@@ -14,43 +14,22 @@
 <div class="collapse @(Model.Filter.GetList().SequenceEqual(new HousingRequirementModel().GetList()) ? "":"show")" id="dropdown-contents">
     <form method="get" asp-controller="Admin" asp-action="TenantList">
 
+        <div class="row mb-3">
+            <div class="col-auto d-grid">
+                @Html.CheckBox("Filter.AcceptsSingleTenant", Model.Filter.AcceptsSingleTenant ?? false, new { @class = "btn-check" })
+                <label asp-for="Filter.AcceptsSingleTenant" class="btn btn-outline-blue shadow-none pill-check">Single tenant</label>
+            </div>
+            <div class="col-auto d-grid">
+                @Html.CheckBox("Filter.AcceptsCouple", Model.Filter.AcceptsCouple ?? false, new { @class = "btn-check" })
+                <label asp-for="Filter.AcceptsCouple" class="btn btn-outline-blue shadow-none pill-check">Couple</label>
+            </div>
+            <div class="col-auto d-grid">
+                @Html.CheckBox("Filter.AcceptsFamily", Model.Filter.AcceptsFamily ?? false, new { @class = "btn-check" })
+                <label asp-for="Filter.AcceptsFamily" class="btn btn-outline-blue shadow-none pill-check">Family (3+)</label>
+            </div>
+        </div>
+
         <div class="row g-3">
-            <div class="col-auto d-grid">
-                @Html.DropDownListFor(
-                    model => model.Filter.AcceptsSingleTenant,
-                    new List<SelectListItem>
-                    {
-                        new("Only single tenants", "true"),
-                        new("No single tenants", "false")
-                    }, 
-                    "Filter by single tenant",
-                    new { @class="form-select" }
-                    )
-            </div>
-            <div class="col-auto d-grid">
-                @Html.DropDownListFor(
-                    model => model.Filter.AcceptsCouple,
-                    new List<SelectListItem>
-                    {
-                        new("Only couples", "true"),
-                        new("No couples", "false")
-                    }, 
-                    "Filter by couple",
-                    new { @class="form-select" }
-                    )
-            </div>
-            <div class="col-auto d-grid">
-                @Html.DropDownListFor(
-                    model => model.Filter.AcceptsFamily,
-                    new List<SelectListItem>
-                    {
-                        new("Only families", "true"),
-                        new("No families", "false")
-                    }, 
-                    "Filter by family",
-                    new { @class="form-select" }
-                    )
-            </div>
             <div class="col-auto d-grid">
                 @Html.DropDownListFor(
                     model => model.Filter.AcceptsPets,

--- a/web/Views/Admin/TenantMatchList.cshtml
+++ b/web/Views/Admin/TenantMatchList.cshtml
@@ -37,9 +37,11 @@
             <td>@tenant.HousingBenefits</td>
             <td>@tenant.Over35</td>
             <td>
-                @using (Html.BeginForm("SendMatchLinkEmail", "Admin", new { propertyLink = Model.CurrentProperty.Description, /*TODO: change this from description to link*/ 
-                                                                                                        tenantEmail = tenant.Email, 
-                                                                                                        currentPropertyId = Model.CurrentProperty.PropertyId }, FormMethod.Post))
+                @using (Html.BeginForm("SendMatchLinkEmail", "Admin", new {
+                    propertyLink = Model.CurrentProperty.Description, /*TODO: change this from description to link*/ 
+                    tenantEmail = tenant.Email, 
+                    currentPropertyId = Model.CurrentProperty.PropertyId }, 
+                    FormMethod.Post))
                 {
                     <button type="submit" class="btn btn-thin btn-outline-primary mx-3">Match</button>
                 }

--- a/web/Views/Admin/TenantMatchList.cshtml
+++ b/web/Views/Admin/TenantMatchList.cshtml
@@ -1,22 +1,7 @@
-﻿@using BricksAndHearts.Services
-@model TenantMatchListModel
+﻿@model TenantMatchListModel
 
 @{
     ViewData["Title"] = "Tenant List";
-}
-
-@{
-    if (TempData["MultipleFlashMessages"] != null)
-    {
-        var flashMessages = TempData["MultipleFlashMessages"] as string[];
-        var flashTypes = TempData["MultipleFlashTypes"] as string[];
-        for (int i = 0; i < flashMessages!.Length; i++)
-        {
-            <div class="alert alert-@flashTypes![i]" role="alert">
-            @flashMessages[i]
-            </div>
-        }
-    }
 }
 
 <h2>Tenant Matches for @Model.CurrentProperty.Address.AddressLine1 @Model.CurrentProperty.Address.AddressLine2 @Model.CurrentProperty.Address.AddressLine3</h2>

--- a/web/Views/Admin/TenantMatchList.cshtml
+++ b/web/Views/Admin/TenantMatchList.cshtml
@@ -1,0 +1,57 @@
+﻿@model TenantMatchListModel
+
+@{
+    ViewData["Title"] = "Tenant List";
+}
+
+@{
+    if (TempData["MultipleFlashMessages"] != null)
+    {
+        var flashMessages = TempData["MultipleFlashMessages"] as string[];
+        var flashTypes = TempData["MultipleFlashTypes"] as string[];
+        for (int i = 0; i < flashMessages!.Length; i++)
+        {
+            <div class="alert alert-@flashTypes![i]" role="alert">
+            @flashMessages[i]
+            </div>
+        }
+    }
+}
+
+<h2>Tenant Matches for @Model.CurrentProperty.Address.AddressLine1 @Model.CurrentProperty.Address.AddressLine2 @Model.CurrentProperty.Address.AddressLine3</h2>
+
+<table class="table">
+    <thead>
+    <tr>
+        <th scope="col">Name</th>
+        <th scope="col">Email</th>
+        <th scope="col">Phone</th>
+        <th scope="col">Postcode</th>
+        <th scope="col">Type</th>
+        <th scope="col">Has Pet?</th>
+        <th scope="col">In ETT?</th>
+        <th scope="col">On Universal Credit?</th>
+        <th scope="col">On Housing Benefits?</th>
+        <th scope="col">Over 35?</th>
+        <th scope="col">Match</th>
+    </tr>
+    </thead>
+    <tbody>
+    @foreach (var tenant in Model.TenantList!)
+    {
+        <tr>
+            <td>@tenant.Name</td>
+            <td>@tenant.Email</td>
+            <td>@tenant.Phone</td>
+            <td>@tenant.Postcode</td>
+            <td>@tenant.Type</td>
+            <td>@tenant.HasPet</td>
+            <td>@tenant.ETT</td>
+            <td>@tenant.UniversalCredit</td>
+            <td>@tenant.HousingBenefits</td>
+            <td>@tenant.Over35</td>
+            <td>MATCH TIME</td>
+        </tr>
+    }
+    </tbody>
+</table>

--- a/web/Views/Admin/TenantMatchList.cshtml
+++ b/web/Views/Admin/TenantMatchList.cshtml
@@ -1,4 +1,5 @@
-﻿@model TenantMatchListModel
+﻿@using BricksAndHearts.Services
+@model TenantMatchListModel
 
 @{
     ViewData["Title"] = "Tenant List";
@@ -50,7 +51,14 @@
             <td>@tenant.UniversalCredit</td>
             <td>@tenant.HousingBenefits</td>
             <td>@tenant.Over35</td>
-            <td>MATCH TIME</td>
+            <td>
+                @using (Html.BeginForm("SendMatchLinkEmail", "Admin", new { propertyLink = Model.CurrentProperty.Description, /*TODO: change this from description to link*/ 
+                                                                                                        tenantEmail = tenant.Email, 
+                                                                                                        currentPropertyId = Model.CurrentProperty.PropertyId }, FormMethod.Post))
+                {
+                    <button type="submit" class="btn btn-thin btn-outline-primary mx-3">Match</button>
+                }
+            </td>
         </tr>
     }
     </tbody>

--- a/web/Views/Property/ViewProperty.cshtml
+++ b/web/Views/Property/ViewProperty.cshtml
@@ -34,8 +34,7 @@
 {
     <div class="row mt-4">
         <div class="col-auto mb-2">
-            @* TODO: Link this to tenant matching page *@
-            <a asp-action="" asp-controller="" class="btn btn-large btn-outline-primary d-table-cell">View matches</a>
+            <a asp-action="TenantMatchList" asp-controller="Admin" asp-route-currentPropertyId="@Model.Property.PropertyId" class="btn btn-large btn-outline-primary d-table-cell">View matches</a>
         </div>
         <div class="col-auto mb-2">
             <a asp-action="GetPublicViewLink" asp-controller="Property" asp-route-propertyId="@Model.Property.PropertyId" class="btn btn-large btn-outline-primary d-table-cell">Get shareable link</a>


### PR DESCRIPTION
Added a simple matching "algorithm" according to the filters we have for tenant sorting. Once the tenant distance ticket is done, this can be sorted by distance (currently sorted by name). Added 2 buttons to get to this page, one from the admin property table and one from the individual property page but only if the user is an admin.
![image](https://user-images.githubusercontent.com/43523985/184835786-4d868cf6-a825-4eca-b491-93a169cc03f3.png)
![image](https://user-images.githubusercontent.com/43523985/184835823-fd380c91-787f-4793-848a-89fa764a78fb.png)
![image](https://user-images.githubusercontent.com/43523985/184835920-77e89616-f969-42aa-8f04-c92295890e5f.png)
Also slightly simplified / refactored the filtering to be more in line with the landlord's requirements. Previously, all filters were exclusive (i.e. having 2 filters on showed the intersection of those 2 filters. Now filters are inclusive for the landlord type (i.e. shows the union of those 2 filters) and exclusive for everything not landlord type based on the filter page, and are inclusive everywhere for the matching algorithm.
