### PR TITLE
BNH-164 & 93 - property deletion

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
@@ -225,7 +225,7 @@ public class PropertyControllerTests : PropertyControllerTestsBase
     #region DeleteProperty
 
     [Fact]
-    public void DeleteProperty_WithExistingProperty_DeletesAndRedirectsToViewProperties()
+    public void DeleteProperty_WithExistingProperty_DeletesPropertyAndImagesAndRedirectsToViewProperties()
     {
         // Arrange
         var fakePropertyDbModel = CreateExamplePropertyDbModel();
@@ -241,11 +241,12 @@ public class PropertyControllerTests : PropertyControllerTestsBase
 
         // Assert
         A.CallTo(() => PropertyService.DeleteProperty(fakePropertyDbModel)).MustHaveHappened();
+        A.CallTo(() => AzureStorage.DeleteContainer("property", fakePropertyDbModel.Id)).MustHaveHappened();
         result.Should().BeOfType<RedirectToActionResult>().Which.ActionName.Should().Be("ViewProperties");
     }
 
     [Fact]
-    public void DeleteProperty_WithNonExistingProperty_Returns404ErrorPage()
+    public void DeleteProperty_WithNonExistingProperty_RedirectsToViewProperties()
     {
         // Arrange
         var fakePropertyDbModel = CreateExamplePropertyDbModel();
@@ -260,7 +261,8 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         // Assert
         A.CallTo(() => PropertyService.GetPropertyByPropertyId(1)).MustHaveHappened();
         A.CallTo(() => PropertyService.DeleteProperty(fakePropertyDbModel)).MustNotHaveHappened();
-        result.Should().BeOfType<StatusCodeResult>().Which.StatusCode.Should().Be(404);
+        A.CallTo(() => AzureStorage.DeleteContainer("property", fakePropertyDbModel.Id)).MustNotHaveHappened();
+        result.Should().BeOfType<RedirectToActionResult>().Which.ActionName.Should().Be("ViewProperties");
     }
 
     #endregion

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -46,12 +46,10 @@ public class PropertyController : AbstractController
             return StatusCode(404);
         }
 
-        var landlordId = propDB.Landlord.Id;
-
-        // Delete property
+        var landlordId = propDB.LandlordId;
         _propertyService.DeleteProperty(propDB);
-
-        // Go to View Properties page
+        _azureStorage.DeleteContainer("property", propertyId);
+        
         return RedirectToAction("ViewProperties", "Landlord", new { id = landlordId });
     }
 


### PR DESCRIPTION
Two small fixes in the property deletion code:
BNH-164: when a property is deleted, the container on Azure Blob Storage which holds the images for that property is also deleted (to avoid storage of unneeded, and mostly inaccessible, files)
BNH-93: deleting a property which did not exist (e.g .by having the same property open in two tabs and deleting it in one tab, then attempting to in the other) was returning a (browser) 405 error - why it was 405, not 404, is slightly unclear. It now returns the user to the list of their properties (if a landlord), admin dashboard (if non-landlord admin) or home page (if nothing important), with a flash message informing them the property does not exist.