### PR TITLE
BNH-141 Style property tables

### DIFF
--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -17,7 +17,8 @@ public class LandlordController : AbstractController
     private readonly IAzureStorage _azureStorage;
 
     public LandlordController(ILogger<LandlordController> logger,
-        ILandlordService landlordService, IPropertyService propertyService, IMailService mailService, IAzureStorage azureStorage)
+        ILandlordService landlordService, IPropertyService propertyService, IMailService mailService,
+        IAzureStorage azureStorage)
     {
         _logger = logger;
         _landlordService = landlordService;
@@ -213,7 +214,7 @@ public class LandlordController : AbstractController
         var listOfProperties = databaseResult.Select(PropertyViewModel.FromDbModel).ToList();
         var landlordProfile = LandlordProfileModel.FromDbModel(await _landlordService.GetLandlordFromId((int)id));
 
-        TempData["Wide"] = true;
+        TempData["FullWidthPage"] = true;
         return View("Properties",
             new PropertiesDashboardViewModel(listOfProperties, listOfProperties.Count, landlordProfile));
     }
@@ -330,7 +331,9 @@ public class LandlordController : AbstractController
         {
             return StatusCode(404);
         }
-        var landlordViewProperties = landlord.Properties.Select(PropertyViewModel.FromDbModel).OrderByDescending(p => p.PropertyId).Take(2);
+
+        var landlordViewProperties = landlord.Properties.Select(PropertyViewModel.FromDbModel)
+            .OrderByDescending(p => p.PropertyId).Take(2);
         var allPropertyDetails = new List<PropertyDetailsViewModel>();
         foreach (var property in landlordViewProperties)
         {
@@ -341,6 +344,7 @@ public class LandlordController : AbstractController
                 Property = property
             });
         }
+
         var viewModel = new LandlordDashboardViewModel
         {
             CurrentLandlord = LandlordProfileModel.FromDbModel(landlord),
@@ -360,7 +364,7 @@ public class LandlordController : AbstractController
             })
             .ToList();
     }
-    
+
     [HttpGet("{propertyId:int}/{fileName}")]
     public async Task<IActionResult> GetImage(int propertyId, string fileName)
     {

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -212,6 +212,8 @@ public class LandlordController : AbstractController
         var databaseResult = _propertyService.GetPropertiesByLandlord(id.Value);
         var listOfProperties = databaseResult.Select(PropertyViewModel.FromDbModel).ToList();
         var landlordProfile = LandlordProfileModel.FromDbModel(await _landlordService.GetLandlordFromId((int)id));
+
+        TempData["Wide"] = true;
         return View("Properties",
             new PropertiesDashboardViewModel(listOfProperties, listOfProperties.Count, landlordProfile));
     }

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -41,19 +41,21 @@ public class PropertyController : AbstractController
             {
                 return RedirectToAction("ViewProperties", "Landlord", new { id = GetCurrentUser().LandlordId });
             }
+
             return RedirectToAction("Index", "Home");
         }
 
         if (GetCurrentUser().IsAdmin == false && GetCurrentUser().LandlordId != propDB.LandlordId)
         {
-            _logger.LogWarning($"User {GetCurrentUser().Id} does not have access to any property with ID {propertyId}.");
+            _logger.LogWarning(
+                $"User {GetCurrentUser().Id} does not have access to any property with ID {propertyId}.");
             return StatusCode(403);
         }
 
         var landlordId = propDB.LandlordId;
         _propertyService.DeleteProperty(propDB);
         _azureStorage.DeleteContainer("property", propertyId);
-        
+
         AddFlashMessage("danger", $"Successfully deleted property with Id {propertyId}");
         return RedirectToAction("ViewProperties", "Landlord", new { id = landlordId });
     }
@@ -89,6 +91,8 @@ public class PropertyController : AbstractController
         var properties = _propertyService.SortProperties(sortBy);
 
         var listOfProperties = properties.Select(PropertyViewModel.FromDbModel).ToList();
+
+        TempData["Wide"] = true;
 
         return View("~/Views/Admin/PropertyList.cshtml",
             new PropertiesDashboardViewModel(listOfProperties.Skip((page - 1) * propPerPage).Take(propPerPage).ToList(),
@@ -426,7 +430,8 @@ public class PropertyController : AbstractController
             if (!isImageResult.isImage)
             {
                 _logger.LogInformation($"Failed to upload {image.FileName}: not in a recognised image format");
-                AddFlashMessage("danger", $"{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: {isImageResult.imageExtString}");               
+                AddFlashMessage("danger",
+                    $"{image.FileName} is not in a recognised image format. Please submit your images in one of the following formats: {isImageResult.imageExtString}");
             }
             else
             {
@@ -478,6 +483,8 @@ public class PropertyController : AbstractController
         _logger.LogInformation("Successfully sorted by location");
         var listOfProperties = properties.Select(PropertyViewModel.FromDbModel).Skip((page - 1) * propPerPage)
             .Take(propPerPage).ToList();
+
+        TempData["Wide"] = true;
 
         return View("~/Views/Admin/PropertyList.cshtml",
             new PropertiesDashboardViewModel(listOfProperties, listOfProperties.Count, null!, page, "Location"));

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -92,7 +92,7 @@ public class PropertyController : AbstractController
 
         var listOfProperties = properties.Select(PropertyViewModel.FromDbModel).ToList();
 
-        TempData["Wide"] = true;
+        TempData["FullWidthPage"] = true;
 
         return View("~/Views/Admin/PropertyList.cshtml",
             new PropertiesDashboardViewModel(listOfProperties.Skip((page - 1) * propPerPage).Take(propPerPage).ToList(),
@@ -394,7 +394,7 @@ public class PropertyController : AbstractController
             })
             .ToList();
     }
-    
+
     [Authorize(Roles = "Landlord, Admin")]
     [HttpGet("{propertyId:int}/{fileName}")]
     public async Task<IActionResult> GetImage(int propertyId, string fileName)
@@ -484,7 +484,7 @@ public class PropertyController : AbstractController
         var listOfProperties = properties.Select(PropertyViewModel.FromDbModel).Skip((page - 1) * propPerPage)
             .Take(propPerPage).ToList();
 
-        TempData["Wide"] = true;
+        TempData["FullWidthPage"] = true;
 
         return View("~/Views/Admin/PropertyList.cshtml",
             new PropertiesDashboardViewModel(listOfProperties, listOfProperties.Count, null!, page, "Location"));

--- a/web/Views/Admin/PropertyList.cshtml
+++ b/web/Views/Admin/PropertyList.cshtml
@@ -1,113 +1,56 @@
 ﻿@model PropertiesDashboardViewModel
 
 @{
-    ViewData["Title"] = "All Properties List";
+    ViewData["Title"] = "Properties";
 }
 
-<h2>All Properties List</h2>
+<div class="mx-md-5">
+    <h1 class="font-h1 mt-5">Properties</h1>
 
-<div class="mb-3">
-    <div class="row">
-        <div class="col-4">
-            @using (Html.BeginForm("SortProperties", "Property", FormMethod.Get))
-            {
-                <select class="form-select" id="sortBy" name="sortBy">
+    <div class="row mt-4">
+        <div class="col-auto me-auto mb-2">
+            <form asp-action="SortProperties" asp-controller="Property" method="get" class="row mx-0">
+                <select class="form-select col h-auto me-3" id="sortBy" name="sortBy">
                     <option value="Availability">Sort by availability</option>
                     <option value="Rent">Sort by rent</option>
                 </select>
-                <button type="submit" class="btn custom-btn-primary"> Display results </button>
-            }
+                <button type="submit" class="btn btn-outline-primary col">Sort</button>
+            </form>
         </div>
-        <div class="col-8">
-            @using (Html.BeginForm("SortPropertiesByLocation", "Property", FormMethod.Get))
-            {
-                <input class="form-control" id="postcode" name="postcode" required placeholder="Enter postcode to sort by location" pattern="([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})"/>
-                <button type="submit" class="btn custom-btn-primary"> Sort </button>
-            }
+        <div class="col-auto me-auto mb-2">
+            <form asp-action="SortPropertiesByLocation" asp-controller="Property" method="get" class="row mx-0">
+                <input class="form-control col h-auto me-3" id="postcode" name="postcode" required placeholder="Enter postcode to sort by location" pattern="([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})"/>
+                <button type="submit" class="btn btn-outline-primary col">Sort</button>
+            </form>
+        </div>
+
+        <div class="col-auto ms-sm-auto">
+            <a asp-controller="Property" asp-action="AddNewProperty_Begin" asp-route-landlordId="@Model.Owner?.LandlordId" class="btn btn-primary">Add new property</a>
         </div>
     </div>
-</div>
 
-<table class="table">
-    <thead>
-    <tr>
-        <th scope="col">Address</th>
-        <th scope="col">Type</th>
-        <th scope="col"># of Bedrooms</th>
-        <th scope="col">Created</th>
-        <th scope="col">Rent (pcm)</th>
-        <th scope="col">Description</th>
-        <th scope="col">Availability</th>
-        <th scope="col">Available From</th>
-        <th scope="col">Landlord's profile</th>
-        <th scope="col">Property information</th>
-        <th scope="col">Matches</th>
-    </tr>
-    </thead>
-    <tbody>
-    @foreach (var property in Model.Properties!)
-    {
-        <tr>
-            <td>@property.Address!.AddressLine1, @property.Address.AddressLine2, @property.Address.AddressLine3, @property.Address.TownOrCity</td>
-            <td>@property.PropertyType</td>
-            <td>@property.NumOfBedrooms</td>
-            <td>@property.CreationTime</td>
-            <td>@property.Rent</td>
-            <td>@property.Description</td>
-            <td>@property.Availability</td>
-            @if (property.AvailableFrom != null)
-            {
-                <td>@property.AvailableFrom.Value.ToString("dd/MM/yyyy")</td>
-            }
-            else
-            {
-                <td></td>
-            }
-            
-            <td>
-                <a type="button" class="btn btn-outline-primary" href="@Url.Action("Profile", "Landlord", new { id = property.LandlordId })">
-                    <i class="bi bi-person"></i>
-                </a>
-            </td>
-            <td>
-                <a class="btn btn-outline-primary position-relative" href="@Url.Action("ViewProperty", "Property", new { propertyId = property.PropertyId })">
-                    <i class="bi bi-house"></i>
-                    @if (property.IsIncomplete)
-                    {
-                        <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-warning">
-                            <i class="bi bi-circle-half"></i> Incomplete
-                            <span class="visually-hidden">Property is incomplete</span>
-                        </span>
-                    }
-                </a>
-            </td>
-            <td>
-                @Html.ActionLink("View matches", "TenantMatchList", "Admin", new { currentPropertyId = property.PropertyId}, 
-                            new { @class = "btn btn-primary" })
-            </td>
-        </tr>
+    <partial name="../Property/_PropertyTable"/>
+
+    @{
+        var from = (Model.Page - 1) * Model.PropPerPage + 1;
+        var to = Math.Min((Model.Page - 1) * Model.PropPerPage + Model.PropPerPage, Model.Total);
     }
-    </tbody>
-</table>
 
-@{ var from = (Model.Page - 1) * Model.PropPerPage + 1;
-    var to = Math.Min((Model.Page - 1) * Model.PropPerPage + Model.PropPerPage, Model.Total);}
+    <p>Displaying properties @from to @to of @Model.Total</p>
 
-<p>Displaying properties @from to @to of @Model.Total</p>
+    @if (Model.Page > 1)
+    {
+        <a type="button" class="btn btn-outline-primary" href="@Url.Action("SortProperties", "Property", new { sortBy = Model.SortBy, page = Model.Page - 1, propPerPage = Model.PropPerPage })">
+            <i class="previous"> Previous </i>
+        </a>
+    }
 
-@if (Model.Page > 1)
-{
-    <a type="button" class="btn btn-outline-primary" href="@Url.Action("SortProperties", "Property", new { sortBy = Model.SortBy, page = Model.Page - 1, propPerPage = Model.PropPerPage })">
-        <i class="previous"> Previous </i>
-    </a>
-}
+    @if (Model.Page <= Model.Total / Model.PropPerPage)
+    {
+        <a type="button" class="btn btn-outline-primary" href="@Url.Action("SortProperties", "Property", new { sortBy = Model.SortBy, page = Model.Page + 1, propPerPage = Model.PropPerPage })">
+            <i class="bi"> Next </i>
+        </a>
+    }
 
-@if (Model.Page <= Model.Total/Model.PropPerPage)
-{
-    <a type="button" class="btn btn-outline-primary" href="@Url.Action("SortProperties", "Property", new { sortBy = Model.SortBy, page = Model.Page + 1, propPerPage = Model.PropPerPage })">
-        <i class="bi"> Next </i>
-    </a>
-}
-
-
+</div>
 

--- a/web/Views/Admin/PropertyList.cshtml
+++ b/web/Views/Admin/PropertyList.cshtml
@@ -10,10 +10,14 @@
     <div class="row mt-4">
         <div class="col-auto me-auto mb-2">
             <form asp-action="SortProperties" asp-controller="Property" method="get" class="row mx-0">
-                <select class="form-select col h-auto me-3" id="sortBy" name="sortBy">
-                    <option value="Availability">Sort by availability</option>
-                    <option value="Rent">Sort by rent</option>
-                </select>
+                @Html.DropDownListFor(
+                    model => model.SortBy,
+                    new List<SelectListItem>
+                    {
+                        new("Sort by availability", "Availability"),
+                        new("Sort by rent", "Rent")
+                    },
+                    new { @class = "form-select col h-auto me-3" })
                 <button type="submit" class="btn btn-outline-primary col">Sort</button>
             </form>
         </div>

--- a/web/Views/Landlord/Properties.cshtml
+++ b/web/Views/Landlord/Properties.cshtml
@@ -1,79 +1,33 @@
+@using BricksAndHearts.Auth
 @model PropertiesDashboardViewModel
 
 @{
-    ViewData["Title"] = "My Properties";
+    ViewData["Title"] = "Properties";
 }
 
-@if (Model.Owner == null)
-{
-    <h2>Landlord's properties</h2>
-}
-else
-{
-    <h2>
-        @Model.Owner.FirstName's properties
-    </h2>
-}
+<div class="mx-md-5">
+    <h1 class="font-h1 mt-5">
+        @if (Model.Owner == null)
+        {
+            @("Landlord's properties")
+        }
+        else if (Model.Owner.LandlordId == ((BricksAndHeartsUser)User.Identity!).LandlordId)
+        {
+            @("My properties")
+        }
+        else
+        {
+            @(Model.Owner.FirstName + "'s properties")
+        }
+    </h1>
 
-<table class="table">
-    <thead>
-    <tr>
-        <th scope="col">#</th>
-        <th scope="col">Address</th>
-        <th scope="col">Type</th>
-        <th scope="col">Bedrooms</th>
-        <th scope="col">Created</th>
-        <th scope="col">Rent (pcm)</th>
-        <th scope="col">Availability</th>
-        <th scope="col">Description</th>
-        <th scope="col">Total units</th>
-        <th scope="col">Occupied units</th>
-        <th scope="col">Available units</th>
-        <th scope="col">Property page</th>
-    </tr>
-    </thead>
-    <tbody>
-    @{
-        var i = 1;
-    }
-    @foreach (var prop in Model.Properties)
-    {
-        <tr>
-            <th scope="row">@i</th>
-            <td>
-                @prop.Address.AddressLine1,
-                @prop.Address.AddressLine2@(prop.Address.AddressLine2 != null ? "," : "")
-                @prop.Address.AddressLine3@(prop.Address.AddressLine3 != null ? "," : "")
-                @prop.Address.TownOrCity,
-                @prop.Address.County,
-                @prop.Address.Postcode
-            </td>
-            <td>@prop.PropertyType</td>
-            <td>@prop.NumOfBedrooms</td>
-            <td>@prop.CreationTime</td>
-            <td>@prop.Rent</td>
-            <td>@prop.Availability</td>
-            <td>
-                <div class="table-maxheight">@prop.Description</div>
-            </td>
-            <td>@prop.TotalUnits</td>
-            <td>@prop.OccupiedUnits</td>
-            <td>@prop.AvailableUnits</td>
-            <td>
-                <a class="btn btn-outline-primary position-relative" href="@Url.Action("ViewProperty", "Property", new { propertyId = prop.PropertyId })">
-                    <p>view</p>
-                    @if (prop.IsIncomplete)
-                    {
-                        <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-warning">
-                            <i class="bi bi-circle-half"></i> Incomplete
-                            <span class="visually-hidden">Property is incomplete</span>
-                        </span>
-                    }
-                </a>
-            </td>
-        </tr>
-        i++;
-    }
-    </tbody>
-</table>
-<a class="btn btn-primary" href="@Url.Action("AddNewProperty_Begin", "Property", new { Model.Owner?.LandlordId })">Add new property</a> @*Add landlord ID*@
+    <div class="row mt-4">
+        @* Sorting and filtering goes here *@
+
+        <div class="col-auto ms-sm-auto">
+            <a asp-controller="Property" asp-action="AddNewProperty_Begin" asp-route-landlordId="@Model.Owner?.LandlordId" class="btn btn-primary">Add new property</a>
+        </div>
+    </div>
+
+    <partial name="../Property/_PropertyTable"/>
+</div>

--- a/web/Views/Property/Details/_AvailabilityPill.cshtml
+++ b/web/Views/Property/Details/_AvailabilityPill.cshtml
@@ -1,4 +1,4 @@
-﻿@model PropertyDetailsViewModel
+﻿@model PropertyViewModel
 
 @functions
 {
@@ -11,7 +11,7 @@
     }
 }
 
-@switch (Model.Property!.Availability)
+@switch (Model.Availability)
 {
     case AvailabilityState.Occupied:
         GetAvailabilityPill("Occupied", "people");

--- a/web/Views/Property/ViewProperty.cshtml
+++ b/web/Views/Property/ViewProperty.cshtml
@@ -9,7 +9,7 @@
         <h1 class="font-h1 d-inline">@Model.Property!.Address.ToShortAddressString()</h1>
     </div>
     <div class="col-auto mb-2 d-flex align-items-center">
-        <partial name="Details/_AvailabilityPill"/>
+        <partial name="Details/_AvailabilityPill" model="Model.Property"/>
     </div>
 </div>
 

--- a/web/Views/Property/_PropertyTable.cshtml
+++ b/web/Views/Property/_PropertyTable.cshtml
@@ -1,0 +1,97 @@
+﻿@model PropertiesDashboardViewModel
+
+@if (Model.Properties.Count == 0)
+{
+    <h2 class="font-h2">No properties found</h2>
+    return;
+}
+<div class="table-responsive mt-4">
+    <table class="table">
+        <thead class="bg-pale-blue">
+        <tr>
+            <th scope="col">Status</th>
+            <th scope="col">Address</th>
+            <th scope="col" style="width: 150px">Type</th>
+            <th scope="col">Bedrooms</th>
+            <th scope="col">Description</th>
+            <th scope="col">Availability</th>
+            <th scope="col">Rent (pcm)</th>
+            <th scope="col">Total units</th>
+            <th scope="col">Available units</th>
+            <th scope="col">Created</th>
+            <th scope="col">Details</th>
+            @if (User.IsInRole("Admin"))
+            {
+                <th scope="col">Landlord</th>
+                <th scope="col">Match</th>
+            }
+        </tr>
+        </thead>
+        <tbody>
+        @foreach (var prop in Model.Properties)
+        {
+            <tr>
+                <td class="text-nowrap">
+                    <partial name="../Property/Details/_AvailabilityPill" model="prop"/>
+                </td>
+                <td>
+                    @prop.Address.AddressLine1,
+                    @prop.Address.AddressLine2@(prop.Address.AddressLine2 != null ? "," : "")
+                    @prop.Address.AddressLine3@(prop.Address.AddressLine3 != null ? "," : "")
+                    @prop.Address.TownOrCity,
+                    @prop.Address.County,
+                    @prop.Address.Postcode
+                </td>
+                <td>@prop.PropertyType</td>
+                <td>@prop.NumOfBedrooms</td>
+                <td>
+                    <div class="table-maxheight property-description">@prop.Description</div>
+                </td>
+                <td>
+                    @if (prop.Availability == AvailabilityState.AvailableSoon && prop.AvailableFrom.HasValue)
+                    {
+                        @("From " + prop.AvailableFrom.Value.ToShortDateString())
+                    }
+                    else
+                    {
+                        @("Now")
+                    }
+                </td>
+                <td>£@prop.Rent</td>
+                @if (prop.TotalUnits > 1)
+                {
+                    <td>@prop.TotalUnits</td>
+                    <td>@prop.AvailableUnits</td>
+                }
+                else
+                {
+                    <td class="bg-pale-blue">N/A</td>
+                    <td class="bg-pale-blue">N/A</td>
+                }
+                <td>@prop.CreationTime?.ToShortDateString()</td>
+                <td>
+                    <a asp-action="ViewProperty" asp-controller="Property" asp-route-propertyId="@prop.PropertyId" class="btn btn-@(User.IsInRole("Admin") ? "outline-" : "")primary">View</a>
+                </td>
+                @if (User.IsInRole("Admin"))
+                {
+                    <td>
+                        <a asp-action="Profile" asp-controller="Landlord" asp-route-id="@prop.LandlordId" class="btn btn-outline-primary">Landlord</a>
+                    </td>
+                    <td>
+                        @if (prop.Availability is AvailabilityState.Available or AvailabilityState.AvailableSoon)
+                        {
+                            // Allow matching
+                            <a asp-action="TenantMatchList" asp-controller="Admin" asp-route-currentPropertyId="@prop.PropertyId" class="btn btn-primary text-nowrap">Find potential tenants</a>
+                        }
+                        else
+                        {
+                            // Don't allow matching
+                            <a class="btn btn-primary text-nowrap disabled bg-grey">Find potential tenants</a>
+                        }
+                    </td>
+                }
+            </tr>
+        }
+        </tbody>
+    </table>
+</div>

--- a/web/Views/Property/_PropertyTable.cshtml
+++ b/web/Views/Property/_PropertyTable.cshtml
@@ -36,8 +36,8 @@
                 </td>
                 <td>
                     @prop.Address.AddressLine1,
-                    @prop.Address.AddressLine2@(prop.Address.AddressLine2 != null ? "," : "")
-                    @prop.Address.AddressLine3@(prop.Address.AddressLine3 != null ? "," : "")
+                    @(prop.Address.AddressLine2 == null ? "" : prop.Address.AddressLine2 + ",")
+                    @(prop.Address.AddressLine3 == null ? "" : prop.Address.AddressLine3 + ",")
                     @prop.Address.TownOrCity,
                     @prop.Address.County,
                     @prop.Address.Postcode

--- a/web/Views/Shared/_Layout.cshtml
+++ b/web/Views/Shared/_Layout.cshtml
@@ -85,7 +85,7 @@
 
 
 <main role="main">
-    <div class="container mt-3 pb-4">
+    <div class="container@(TempData["Wide"] is true ? "-fluid" : "") mt-3 pb-4">
         @if (TempData["FlashMessages"] != null && TempData["FlashTypes"] != null)
         {
             var flashMessages = TempData["FlashMessages"] as List<string>;

--- a/web/Views/Shared/_Layout.cshtml
+++ b/web/Views/Shared/_Layout.cshtml
@@ -85,7 +85,7 @@
 
 
 <main role="main">
-    <div class="container@(TempData["Wide"] is true ? "-fluid" : "") mt-3 pb-4">
+    <div class="container@(TempData["FullWidthPage"] is true ? "-fluid" : "") mt-3 pb-4">
         @if (TempData["FlashMessages"] != null && TempData["FlashTypes"] != null)
         {
             var flashMessages = TempData["FlashMessages"] as List<string>;

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -113,13 +113,18 @@ body {
     border-color: var(--red);
 }
 
-.card-home{
+.btn.disabled {
+    background-color: grey;
+    border-color: grey;
+}
+
+.card-home {
     width: 80%;
     height: 100%;
     background-color: var(--blue);
 }
 
-.bi-register{
+.bi-register {
     font-size: 85px;
     background-color: var(--blue);
     color: var(--white)
@@ -349,6 +354,7 @@ td, th {
     border-width: 1px;
     border-color: var(--blue50);
     padding-left: 1rem !important;
+    padding-right: 1rem !important;
 }
 
 th {
@@ -357,9 +363,12 @@ th {
 }
 
 .table-maxheight {
-    overflow-y: scroll;
-    overflow-x: auto;
+    overflow-y: auto;
     max-height: 200px;
+}
+
+.bg-pale-blue {
+    background-color: var(--paleBlue) !important;
 }
 
 .profile-photo-lg {
@@ -398,10 +407,6 @@ th {
     max-width: 688px;
     height: 100%;
     display: block;
-}
-
-.property-img-lg{
-    
 }
 
 .property-img-sm {


### PR DESCRIPTION
- Admin and landlord property lists now share a partial for the table itself
- Table styled to match designs
- On mobile, table is scrollable
- To make the wide tables fit, we change from a `container` to a `container-fluid` for pages which have `TempData["Wide"]` set to `true`

Landlord:
![image](https://user-images.githubusercontent.com/41208630/185435493-e26aa646-cbb4-454f-ad43-9c3ce1b25d3e.png)

Admin:
![image](https://user-images.githubusercontent.com/41208630/185435803-e2ab4c50-0c80-43f4-8e28-2d8ed5b30c60.png)

Landlord mobile:
![image](https://user-images.githubusercontent.com/41208630/185435656-e0ec449a-7945-4b09-8e17-dd98d4b13b68.png)
