### PR TITLE
BNH-171 - fix flash messages

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Admin/AdminControllerTestsBase.cs
@@ -17,7 +17,7 @@ public class AdminControllerTestsBase : ControllerTestsBase
     protected readonly IPropertyService PropertyService;
     protected readonly ICsvImportService CsvImportService;
     protected readonly IMailService MailService;
-    protected IEnumerable<string>? FlashMessages => UnderTest.TempData["FlashMessages"] as List<string>;
+    protected IEnumerable<string>? FlashMessages => UnderTest.TempData["FlashMessages"] as string[];
     protected readonly AdminController UnderTest;
 
     protected AdminControllerTestsBase()

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTestsBase.cs
@@ -20,7 +20,7 @@ public class LandlordControllerTestsBase : ControllerTestsBase
     protected readonly IMailService MailService;
     protected readonly IPropertyService PropertyService;
     protected readonly IAzureStorage AzureStorage;
-    protected IEnumerable<string>? FlashMessages => UnderTest.TempData["FlashMessages"] as List<string>;
+    protected IEnumerable<string>? FlashMessages => UnderTest.TempData["FlashMessages"] as string[];
     protected readonly LandlordController UnderTest;
 
     protected LandlordControllerTestsBase()

--- a/web/Controllers/AbstractController.cs
+++ b/web/Controllers/AbstractController.cs
@@ -22,11 +22,11 @@ public abstract class AbstractController : Controller
         TempData["FlashMessages"] ??= new string[] {};
 
         var flashMessageArray = TempData["FlashMessages"] as string[];
-        var flashMessageList = new List<string>(flashMessageArray);
+        var flashMessageList = new List<string>(flashMessageArray!);
         flashMessageList.Add(flashMessage);
         
         var flashTypeArray = TempData["FlashTypes"] as string[];
-        var flashTypeList = new List<string>(flashTypeArray);
+        var flashTypeList = new List<string>(flashTypeArray!);
         flashTypeList.Add(flashType);
 
         TempData["FlashMessages"] = flashMessageList.ToArray();

--- a/web/Controllers/AbstractController.cs
+++ b/web/Controllers/AbstractController.cs
@@ -18,10 +18,18 @@ public abstract class AbstractController : Controller
 
     protected void AddFlashMessage(string flashType, string flashMessage)
     {
-        TempData["FlashTypes"] ??= new List<string>();
-        TempData["FlashMessages"] ??= new List<string>();
+        TempData["FlashTypes"] ??= new string[] {};
+        TempData["FlashMessages"] ??= new string[] {};
+
+        var flashMessageArray = TempData["FlashMessages"] as string[];
+        var flashMessageList = new List<string>(flashMessageArray);
+        flashMessageList.Add(flashMessage);
         
-        (TempData["FlashTypes"] as List<string>)!.Add(flashType);
-        (TempData["FlashMessages"] as List<string>)!.Add(flashMessage);
+        var flashTypeArray = TempData["FlashTypes"] as string[];
+        var flashTypeList = new List<string>(flashTypeArray);
+        flashTypeList.Add(flashType);
+
+        TempData["FlashMessages"] = flashMessageList.ToArray();
+        TempData["FlashTypes"] = flashTypeList.ToArray();
     }
 }

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -126,6 +126,7 @@ public class AdminController : AbstractController
     [HttpGet]
     public async Task<ActionResult> GetAdminList()
     {
+        AddFlashMessage("success", "If you can see this, it's fixed!");
         var adminLists = await _adminService.GetAdminLists();
         AdminListModel adminListModel = new AdminListModel(adminLists.CurrentAdmins, adminLists.PendingAdmins);
         return View("AdminList", adminListModel);

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -126,7 +126,6 @@ public class AdminController : AbstractController
     [HttpGet]
     public async Task<ActionResult> GetAdminList()
     {
-        AddFlashMessage("success", "If you can see this, it's fixed!");
         var adminLists = await _adminService.GetAdminLists();
         AdminListModel adminListModel = new AdminListModel(adminLists.CurrentAdmins, adminLists.PendingAdmins);
         return View("AdminList", adminListModel);

--- a/web/Views/Shared/_Layout.cshtml
+++ b/web/Views/Shared/_Layout.cshtml
@@ -91,8 +91,9 @@
         {
             for (var i = 0; i < flashMessages.Length; i++)
             {
-                <div class="alert alert-@flashTypes[i]" role="alert">
+                <div class="alert alert-@flashTypes[i] alert-dismissible" role="alert">
                     @flashMessages[i]
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                 </div>
             }
         }

--- a/web/Views/Shared/_Layout.cshtml
+++ b/web/Views/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
 ﻿@using BricksAndHearts.Auth
+@using System.Collections
 <!DOCTYPE html>
 <html lang="en" class="h-100">
 
@@ -86,13 +87,11 @@
 
 <main role="main">
     <div class="container@(TempData["FullWidthPage"] is true ? "-fluid" : "") mt-3 pb-4">
-        @if (TempData["FlashMessages"] != null && TempData["FlashTypes"] != null)
+        @if (TempData["FlashMessages"] is string[] flashMessages && TempData["FlashTypes"] is string[] flashTypes)
         {
-            var flashMessages = TempData["FlashMessages"] as List<string>;
-            var flashTypes = TempData["FlashTypes"] as List<string>;
-            for (var i = 0; i < flashMessages!.Count; i++)
+            for (var i = 0; i < flashMessages.Length; i++)
             {
-                <div class="alert alert-@flashTypes![i]" role="alert">
+                <div class="alert alert-@flashTypes[i]" role="alert">
                     @flashMessages[i]
                 </div>
             }


### PR DESCRIPTION
AddFlashMessages method changed to be very specific about data types at every possible stage - avoiding confusion between List<string> and string[] seems to be the solution to avoiding the flash message-related errors we've had today.

Also, added a close button to flash messages.