### PR TITLE
BNH-147 - disable landlords

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandLordControllerUnassignedTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandLordControllerUnassignedTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using BricksAndHearts.Database;
+using BricksAndHearts.Enums;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using FakeItEasy;
@@ -43,7 +44,7 @@ public class LandLordControllerUnassignedTests : LandlordControllerTestsBase
                       + "\n";
         var subject = "Bricks&Hearts - landlord registration notification";
         A.CallTo(() => LandlordService.RegisterLandlord(formResultModel))
-            .Returns((ILandlordService.LandlordRegistrationResult.Success, returnedLandlord));
+            .Returns((LandlordRegistrationResult.Success, returnedLandlord));
         A.CallTo(() => MailService.SendMsg(
             A<string>.That.Matches(s => s == msgBody), A<string>.That.Matches(s => s == subject),
             A<List<string>>.Ignored, A<string>.Ignored,
@@ -78,7 +79,7 @@ public class LandLordControllerUnassignedTests : LandlordControllerTestsBase
         formResultModel.Address.AddressLine1 = "Test Road";
         // Act
         A.CallTo(() => LandlordService.RegisterLandlord(formResultModel))
-            .Returns((ILandlordService.LandlordRegistrationResult.Success, returnedLandlord));
+            .Returns((LandlordRegistrationResult.Success, returnedLandlord));
         A.CallTo(() => MailService.SendMsg(
             A<string>.Ignored, A<string>.Ignored, A<List<string>>.Ignored, A<string>.Ignored, A<string>.Ignored
         )).WithAnyArguments().DoesNothing();

--- a/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Landlord/LandlordControllerTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using BricksAndHearts.Database;
+using BricksAndHearts.Enums;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using FakeItEasy;
@@ -39,7 +40,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         formResultModel.Address.AddressLine1 = "Test Road";
 
         A.CallTo(() => LandlordService.RegisterLandlord(formResultModel, unregisteredUser))
-            .Returns((ILandlordService.LandlordRegistrationResult.Success, returnedLandlord));
+            .Returns((LandlordRegistrationResult.Success, returnedLandlord));
 
         // Act
         var result = await UnderTest.RegisterPost(formResultModel) as RedirectToActionResult;
@@ -60,7 +61,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         var landlordUser = CreateLandlordUser();
         var landlordProfile = new LandlordProfileModel { LandlordId = landlordUser.Id, MembershipId = "abc" };
         A.CallTo(() => LandlordService.ApproveLandlord(landlordUser.Id, adminUser, "abc"))
-            .Returns(ILandlordService.ApproveLandlordResult.Success);
+            .Returns(ApproveLandlordResult.Success);
 
         // Act
         await UnderTest.ApproveCharter(landlordProfile);
@@ -98,7 +99,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         var landlordUser = CreateLandlordUser();
         var landlordProfile = new LandlordProfileModel { LandlordId = landlordUser.Id, MembershipId = "abc" };
         A.CallTo(() => LandlordService.DisableOrEnableLandlord(landlordUser.Id, action))
-            .Returns(ILandlordService.DisableOrEnableLandlordResult.Success);
+            .Returns(DisableOrEnableLandlordResult.Success);
 
         // Act
         var result = await UnderTest.DisableOrEnableLandlord(landlordProfile, action);
@@ -120,7 +121,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         var landlordUser = CreateLandlordUser();
         var landlordProfile = new LandlordProfileModel { LandlordId = landlordUser.Id, MembershipId = "abc" };
         A.CallTo(() => LandlordService.DisableOrEnableLandlord(landlordUser.Id, action))
-            .Returns(ILandlordService.DisableOrEnableLandlordResult.ErrorLandlordNotFound);
+            .Returns(DisableOrEnableLandlordResult.ErrorLandlordNotFound);
 
         // Act
         var result = await UnderTest.DisableOrEnableLandlord(landlordProfile, action);
@@ -142,7 +143,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         var landlordUser = CreateLandlordUser();
         var landlordProfile = new LandlordProfileModel { LandlordId = landlordUser.Id, MembershipId = "abc" };
         A.CallTo(() => LandlordService.DisableOrEnableLandlord(landlordUser.Id, action))
-            .Returns(ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState);
+            .Returns(DisableOrEnableLandlordResult.ErrorAlreadyInState);
 
         // Act
         var result = await UnderTest.DisableOrEnableLandlord(landlordProfile, action);
@@ -208,7 +209,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         A.CallTo(() => LandlordService.CheckForDuplicateEmail(landlordProfileModel)).Returns(false);
         A.CallTo(() => LandlordService.CheckForDuplicateMembershipId(landlordProfileModel)).Returns(false);
         A.CallTo(() => LandlordService.EditLandlordDetails(landlordProfileModel))
-            .Returns(ILandlordService.LandlordRegistrationResult.Success);
+            .Returns(LandlordRegistrationResult.Success);
 
         // Act
         var result = await UnderTest.EditProfileUpdate(landlordProfileModel);
@@ -339,7 +340,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         var landlordUser = CreateLandlordUser();
         const string inviteLink = "11111";
         A.CallTo(() => LandlordService.LinkExistingLandlordWithUser(inviteLink, landlordUser))
-            .Returns(ILandlordService.LinkUserWithLandlordResult.ErrorLinkDoesNotExist);
+            .Returns(LinkUserWithLandlordResult.ErrorLinkDoesNotExist);
         MakeUserPrincipalInController(landlordUser, UnderTest);
 
         // Act
@@ -360,7 +361,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         const string inviteLink = "11111";
 
         A.CallTo(() => LandlordService.LinkExistingLandlordWithUser(inviteLink, landlordUser))
-            .Returns(ILandlordService.LinkUserWithLandlordResult.ErrorUserAlreadyHasLandlordRecord);
+            .Returns(LinkUserWithLandlordResult.ErrorUserAlreadyHasLandlordRecord);
         MakeUserPrincipalInController(landlordUser, UnderTest);
 
         // Act
@@ -380,7 +381,7 @@ public class LandlordControllerTests : LandlordControllerTestsBase
         const string inviteLink = "11111";
 
         A.CallTo(() => LandlordService.LinkExistingLandlordWithUser(inviteLink, nonLandlordUser))
-            .Returns(ILandlordService.LinkUserWithLandlordResult.Success);
+            .Returns(LinkUserWithLandlordResult.Success);
         MakeUserPrincipalInController(nonLandlordUser, UnderTest);
 
         // Act

--- a/BricksAndHearts.UnitTests/ServiceTests/Landlord/LandlordServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Landlord/LandlordServiceTests.cs
@@ -139,7 +139,88 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         context.Landlords.Single(u => u.Id == 2).ApprovalTime.Should().BeCloseTo(DateTime.Now, 1.Seconds());
         context.Landlords.Single(u => u.Id == 2).ApprovalAdminId.Should().Be(user.Id);
         context.Landlords.Single(u => u.Id == 2).MembershipId.Should().Be(membershipId);
+    }
+    
+    [Fact]
+    public async void DisableOrEnableLandlord_ReturnsLandlordNotFound_ForNonexistentLandlord()
+    {
+        // Arrange
+        await using var context = Fixture.CreateReadContext();
+        var service = new LandlordService(context);
+
+        // Act
+        var result = await service.DisableOrEnableLandlord(1000, "disable");
+
+        // Assert
+        result.Should().Be(ILandlordService.DisableOrEnableLandlordResult.ErrorLandlordNotFound);
+    }
+    
+    [Fact]
+    public async void DisableOrEnableLandlord_WithDisable_ReturnsLandlordAlreadyInState_ForDisabledLandlord()
+    {
+        // Arrange
+        await using var context = Fixture.CreateReadContext();
+        var service = new LandlordService(context);
+
+        // Act
+        var result = await service.DisableOrEnableLandlord(8, "disable");
+
+        // Assert
+        result.Should().Be(ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState);
+    }
+    
+    [Fact]
+    public async void DisableOrEnableLandlord_WithEnable_ReturnsLandlordAlreadyInState_ForEnabledLandlord()
+    {
+        // Arrange
+        await using var context = Fixture.CreateReadContext();
+        var service = new LandlordService(context);
+
+        // Act
+        var result = await service.DisableOrEnableLandlord(7, "enable");
+
+        // Assert
+        result.Should().Be(ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState);
+    }
+
+    [Fact]
+    public async void DisableOrEnableLandlord_WithDisable_DisablesLandlordAndReturnsSuccess_ForEnabledLandlord()
+    {
+        // Arrange
+        await using var context = Fixture.CreateWriteContext();
+        var service = new LandlordService(context);
+        context.Landlords.Single(u => u.Id == 7).Disabled.Should().BeFalse();
         
+        // Act
+        var result = await service.DisableOrEnableLandlord(7, "disable");
+        
+        // Before assert we need to clear the context's change tracker so that the following database queries actually
+        // query the database, as if this were a new context. This should be done for all write tests.
+        context.ChangeTracker.Clear();
+
+        // Assert
+        result.Should().Be(ILandlordService.DisableOrEnableLandlordResult.Success);
+        context.Landlords.Single(u => u.Id == 7).Disabled.Should().BeTrue();
+    }
+    
+    [Fact]
+    public async void DisableOrEnableLandlord_WithEnable_EnablesLandlordAndReturnsSuccess_ForDisabledLandlord()
+    {
+        // Arrange
+        await using var context = Fixture.CreateWriteContext();
+        var service = new LandlordService(context);
+        context.Landlords.Single(u => u.Id == 8).Disabled.Should().BeTrue();
+        
+        // Act
+        var result = await service.DisableOrEnableLandlord(8, "enable");
+        
+        // Before assert we need to clear the context's change tracker so that the following database queries actually
+        // query the database, as if this were a new context. This should be done for all write tests.
+        context.ChangeTracker.Clear();
+
+        // Assert
+        result.Should().Be(ILandlordService.DisableOrEnableLandlordResult.Success);
+        context.Landlords.Single(u => u.Id == 8).Disabled.Should().BeFalse();
     }
 
     [Fact]
@@ -271,7 +352,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
 
         // Assert
         result.Should().BeOfType<LandlordCountModel>();
-        result.RegisteredLandlords.Should().Be(6);
+        result.RegisteredLandlords.Should().Be(8);
         result.ApprovedLandlords.Should().Be(5);
     }
 

--- a/BricksAndHearts.UnitTests/ServiceTests/Landlord/LandlordServiceTests.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/Landlord/LandlordServiceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Claims;
 using BricksAndHearts.Auth;
 using BricksAndHearts.Database;
+using BricksAndHearts.Enums;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using FakeItEasy;
@@ -98,7 +99,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         var result = await service.ApproveLandlord(1000, user, membershipId);
 
         // Assert
-        result.Should().Be(ILandlordService.ApproveLandlordResult.ErrorLandlordNotFound);
+        result.Should().Be(ApproveLandlordResult.ErrorLandlordNotFound);
     }
     
     [Fact]
@@ -114,7 +115,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         var result = await service.ApproveLandlord(1, user, membershipId);
 
         // Assert
-        result.Should().Be(ILandlordService.ApproveLandlordResult.ErrorAlreadyApproved);
+        result.Should().Be(ApproveLandlordResult.ErrorAlreadyApproved);
     }
 
     [Fact]
@@ -134,7 +135,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         context.ChangeTracker.Clear();
 
         // Assert
-        result.Should().Be(ILandlordService.ApproveLandlordResult.Success);
+        result.Should().Be(ApproveLandlordResult.Success);
         context.Landlords.Single(u => u.Id == 2).CharterApproved.Should().BeTrue();
         context.Landlords.Single(u => u.Id == 2).ApprovalTime.Should().BeCloseTo(DateTime.Now, 1.Seconds());
         context.Landlords.Single(u => u.Id == 2).ApprovalAdminId.Should().Be(user.Id);
@@ -152,7 +153,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         var result = await service.DisableOrEnableLandlord(1000, "disable");
 
         // Assert
-        result.Should().Be(ILandlordService.DisableOrEnableLandlordResult.ErrorLandlordNotFound);
+        result.Should().Be(DisableOrEnableLandlordResult.ErrorLandlordNotFound);
     }
     
     [Fact]
@@ -166,7 +167,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         var result = await service.DisableOrEnableLandlord(8, "disable");
 
         // Assert
-        result.Should().Be(ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState);
+        result.Should().Be(DisableOrEnableLandlordResult.ErrorAlreadyInState);
     }
     
     [Fact]
@@ -180,7 +181,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         var result = await service.DisableOrEnableLandlord(7, "enable");
 
         // Assert
-        result.Should().Be(ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState);
+        result.Should().Be(DisableOrEnableLandlordResult.ErrorAlreadyInState);
     }
 
     [Fact]
@@ -199,7 +200,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         context.ChangeTracker.Clear();
 
         // Assert
-        result.Should().Be(ILandlordService.DisableOrEnableLandlordResult.Success);
+        result.Should().Be(DisableOrEnableLandlordResult.Success);
         context.Landlords.Single(u => u.Id == 7).Disabled.Should().BeTrue();
     }
     
@@ -219,7 +220,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         context.ChangeTracker.Clear();
 
         // Assert
-        result.Should().Be(ILandlordService.DisableOrEnableLandlordResult.Success);
+        result.Should().Be(DisableOrEnableLandlordResult.Success);
         context.Landlords.Single(u => u.Id == 8).Disabled.Should().BeFalse();
     }
 
@@ -268,7 +269,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
 
         // Assert
         context.Landlords.Single(u => u.Id == 3).Email.Should().BeEquivalentTo("NewEmail@Boring.com");
-        result.Should().Be(ILandlordService.LandlordRegistrationResult.Success);
+        result.Should().Be(LandlordRegistrationResult.Success);
     }
 
     #region CheckForDuplicateEmail
@@ -370,7 +371,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         var result = await service.LinkExistingLandlordWithUser(inviteLink, nonAdminUser);
 
         // Assert
-        result.Should().Be(ILandlordService.LinkUserWithLandlordResult.ErrorLinkDoesNotExist);
+        result.Should().Be(LinkUserWithLandlordResult.ErrorLinkDoesNotExist);
     }
 
     [Fact]
@@ -404,7 +405,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         var result = await service.LinkExistingLandlordWithUser(inviteLink, user);
 
         // Assert
-        result.Should().Be(ILandlordService.LinkUserWithLandlordResult.ErrorUserAlreadyHasLandlordRecord);
+        result.Should().Be(LinkUserWithLandlordResult.ErrorUserAlreadyHasLandlordRecord);
     }
 
     [Fact]
@@ -423,7 +424,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         // Assert
         context.ChangeTracker.Clear();
 
-        result.Should().Be(ILandlordService.ApproveLandlordResult.Success);
+        result.Should().Be(ApproveLandlordResult.Success);
 
         landlord = context.Landlords.Single(l => l.Email == "test.landlord2@gmail.com");
         landlord.CharterApproved.Should().BeTrue();
@@ -447,7 +448,7 @@ public class LandlordServiceTests : IClassFixture<TestDatabaseFixture>
         // Assert
         context.ChangeTracker.Clear();
 
-        result.Should().Be(ILandlordService.ApproveLandlordResult.ErrorDuplicateMembershipId);
+        result.Should().Be(ApproveLandlordResult.ErrorDuplicateMembershipId);
 
         landlord = context.Landlords.Single(l => l.Email == "test.landlord2@gmail.com");
         landlord.CharterApproved.Should().BeFalse();

--- a/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
+++ b/BricksAndHearts.UnitTests/ServiceTests/TestDatabaseFixture.cs
@@ -47,7 +47,9 @@ public class TestDatabaseFixture
                     CreateLandlordWithLink(), // landlordId = 3
                     CreateUnlinkedLandlordWithLink(), // landlordId = 4
                     CreateLandlordWithMembershipId(5), // landlordId = 5
-                    CreateLandlordWithMembershipId(6) // landlordId = 6
+                    CreateLandlordWithMembershipId(6), // landlordId = 6
+                    CreateEnabledLandlord(),
+                    CreateDisabledLandlord()
                 );
 
                 context.Users.AddRange(
@@ -360,6 +362,46 @@ public class TestDatabaseFixture
                 County = "county",
                 Postcode = "cb2 1la"
             }
+        };
+    }
+    
+    private static LandlordDbModel CreateEnabledLandlord()
+    {
+        return new LandlordDbModel
+        {
+            Email = "test.landlord7@gmail.com",
+            FirstName = "Landlord7Approved",
+            LastName = "Landlord7Sur",
+            Title = "Mr",
+            Phone = "01189998819991197253",
+            LandlordType = "Non profit",
+            AddressLine1 = "adr1",
+            AddressLine2 = "adr2",
+            AddressLine3 = "adr3",
+            TownOrCity = "city",
+            County = "county",
+            Postcode = "cb2 1la",
+            Disabled = false
+        };
+    }
+
+    private static LandlordDbModel CreateDisabledLandlord()
+    {
+        return new LandlordDbModel
+        {
+            Email = "test.landlord8@gmail.com",
+            FirstName = "Landlord8Unapproved",
+            LastName = "Landlord8Sur",
+            Title = "Mr",
+            Phone = "01189998819991197253",
+            LandlordType = "Non profit",
+            AddressLine1 = "adr1",
+            AddressLine2 = "adr2",
+            AddressLine3 = "adr3",
+            TownOrCity = "city",
+            County = "county",
+            Postcode = "cb2 1la",
+            Disabled = true
         };
     }
 

--- a/web/Auth/ClaimsTransformer.cs
+++ b/web/Auth/ClaimsTransformer.cs
@@ -51,8 +51,11 @@ public class ClaimsTransformer : IClaimsTransformation
         var claims = new List<Claim>(existingClaimsIdentity.Claims);
         // If they're an admin in the database, add the role to their claims
         if (databaseUser.IsAdmin) claims.Add(new Claim(ClaimTypes.Role, "Admin"));
-        if (databaseUser.LandlordId != null) claims.Add(new Claim(ClaimTypes.Role, "Landlord"));
-
+        if (databaseUser.LandlordId != null)
+        {
+            var userLandlord = _context.Landlords.FirstOrDefault(l => l.Id == databaseUser.LandlordId);
+            if (userLandlord != null && !userLandlord.Disabled){ claims.Add(new Claim(ClaimTypes.Role, "Landlord"));}
+        }
         // Build and return our new user principal
         var newClaimsIdentity =
             new BricksAndHeartsUser(databaseUser, claims, existingClaimsIdentity.AuthenticationType);

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -1,4 +1,5 @@
 ﻿using BricksAndHearts.Database;
+using BricksAndHearts.Enums;
 using BricksAndHearts.Services;
 using BricksAndHearts.ViewModels;
 using Microsoft.AspNetCore.Authorization;
@@ -64,7 +65,7 @@ public class LandlordController : AbstractController
         }
 
         var user = CurrentUser;
-        ILandlordService.LandlordRegistrationResult result;
+        LandlordRegistrationResult result;
         LandlordDbModel? landlord;
 
         if (createModel.Unassigned == false)
@@ -82,7 +83,7 @@ public class LandlordController : AbstractController
 
         switch (result)
         {
-            case ILandlordService.LandlordRegistrationResult.Success:
+            case LandlordRegistrationResult.Success:
                 _logger.LogInformation("Successfully created landlord for user {UserId}", user.Id);
                 var msgBody = "A Landlord has just registered\n"
                               + "\n"
@@ -101,17 +102,17 @@ public class LandlordController : AbstractController
                 _mailService.TrySendMsgInBackground(msgBody, subject);
                 return RedirectToAction(nameof(Profile), "Landlord", new { landlord!.Id });
 
-            case ILandlordService.LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered:
+            case LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered:
                 _logger.LogWarning("Email already registered {Email}", createModel.Email);
                 ModelState.AddModelError("Email", "Email already registered");
                 return View("Register", createModel);
 
-            case ILandlordService.LandlordRegistrationResult.ErrorLandlordMembershipIdAlreadyRegistered:
+            case LandlordRegistrationResult.ErrorLandlordMembershipIdAlreadyRegistered:
                 _logger.LogWarning("Membership Id already registered {MembershipId}", createModel.MembershipId);
                 ModelState.AddModelError("MembershipId", "Membership Id already registered");
                 return View("Register", createModel);
 
-            case ILandlordService.LandlordRegistrationResult.ErrorUserAlreadyHasLandlordRecord:
+            case LandlordRegistrationResult.ErrorUserAlreadyHasLandlordRecord:
                 _logger.LogWarning("User {UserId} already associated with landlord", user.Id);
                 AddFlashMessage("warning", "Already registered");
                 return RedirectToAction(nameof(MyProfile));
@@ -174,19 +175,19 @@ public class LandlordController : AbstractController
             flashMessageType;
         switch (result)
         {
-            case ILandlordService.ApproveLandlordResult.ErrorLandlordNotFound:
+            case ApproveLandlordResult.ErrorLandlordNotFound:
                 flashMessageBody = "Sorry, it appears that no landlord with this ID exists.";
                 flashMessageType = "warning";
                 break;
-            case ILandlordService.ApproveLandlordResult.ErrorAlreadyApproved:
+            case ApproveLandlordResult.ErrorAlreadyApproved:
                 flashMessageBody = "The charter for this landlord has already been approved.";
                 flashMessageType = "warning";
                 break;
-            case ILandlordService.ApproveLandlordResult.ErrorDuplicateMembershipId:
+            case ApproveLandlordResult.ErrorDuplicateMembershipId:
                 flashMessageBody = "This membership ID already exists for another user.";
                 flashMessageType = "warning";
                 break;
-            case ILandlordService.ApproveLandlordResult.Success:
+            case ApproveLandlordResult.Success:
                 flashMessageBody = "Successfully approved landlord charter.";
                 flashMessageType = "success";
                 break;
@@ -210,15 +211,15 @@ public class LandlordController : AbstractController
         string flashMessageBody, flashMessageType;
         switch (result)
         {
-            case ILandlordService.DisableOrEnableLandlordResult.ErrorLandlordNotFound:
+            case DisableOrEnableLandlordResult.ErrorLandlordNotFound:
                 flashMessageBody = "Sorry, it appears that no landlord with this ID exists.";
                 flashMessageType = "warning";
                 break;
-            case ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState:
+            case DisableOrEnableLandlordResult.ErrorAlreadyInState:
                 flashMessageBody = $"This landlord has already been {action}d.";
                 flashMessageType = "warning";
                 break;
-            case ILandlordService.DisableOrEnableLandlordResult.Success:
+            case DisableOrEnableLandlordResult.Success:
                 flashMessageBody = $"Successfully {action}d landlord.";
                 flashMessageType = "success";
                 break;
@@ -344,14 +345,14 @@ public class LandlordController : AbstractController
         var result = await _landlordService.LinkExistingLandlordWithUser(inviteLink, user);
         switch (result)
         {
-            case ILandlordService.LinkUserWithLandlordResult.ErrorLinkDoesNotExist:
+            case LinkUserWithLandlordResult.ErrorLinkDoesNotExist:
                 _logger.LogWarning("Invite Link {Link} does not work", inviteLink);
                 return RedirectToAction(nameof(Invite), new { inviteLink });
-            case ILandlordService.LinkUserWithLandlordResult.ErrorUserAlreadyHasLandlordRecord:
+            case LinkUserWithLandlordResult.ErrorUserAlreadyHasLandlordRecord:
                 _logger.LogWarning("User {UserId} already associated with landlord", user.Id);
                 AddFlashMessage("warning", $"User already registered with landlord (landlordId = {user.LandlordId})");
                 return RedirectToAction(nameof(MyProfile));
-            case ILandlordService.LinkUserWithLandlordResult.Success:
+            case LinkUserWithLandlordResult.Success:
                 _logger.LogInformation("Successfully registered landlord with user {UserId}", user.Id);
                 AddFlashMessage("success",
                     $"User {user.Id} successfully linked with landlord (landlordId = {user.LandlordId})");

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -121,6 +121,7 @@ public class LandlordController : AbstractController
         }
     }
 
+    [Authorize(Roles = "Admin, Landlord")]
     [HttpGet("{id:int}/profile")]
     public async Task<ActionResult> Profile([FromRoute] int id)
     {
@@ -141,6 +142,7 @@ public class LandlordController : AbstractController
         return View("Profile", viewModel);
     }
 
+    [Authorize(Roles = "Admin, Landlord")]
     [HttpGet("me/profile")]
     public async Task<ActionResult> MyProfile()
     {
@@ -231,6 +233,7 @@ public class LandlordController : AbstractController
         return RedirectToAction("Profile", "Landlord", new { Id = landlord.LandlordId.Value });
     }
 
+    [Authorize(Roles = "Admin, Landlord")]
     [HttpGet]
     [Route("me/properties")]
     [Route("{id:int}/properties")]
@@ -258,6 +261,7 @@ public class LandlordController : AbstractController
             new PropertyListModel(listOfProperties, properties.Count, landlordProfile, page));
     }
 
+    [Authorize(Roles = "Admin, Landlord")]
     [HttpGet("{landlordId:int}/profile/edit")]
     public async Task<ActionResult> EditProfilePage(int? landlordId)
     {
@@ -276,6 +280,7 @@ public class LandlordController : AbstractController
         return View("EditProfilePage", LandlordProfileModel.FromDbModel(landlordFromDb));
     }
 
+    [Authorize(Roles = "Admin, Landlord")]
     [HttpPost("profile/edit")]
     public async Task<ActionResult> EditProfileUpdate([FromForm] LandlordProfileModel editModel)
     {

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -198,6 +198,38 @@ public class LandlordController : AbstractController
         AddFlashMessage(flashMessageType, flashMessageBody);
         return RedirectToAction(nameof(Profile), "Landlord", new { Id = landlord.LandlordId.Value });
     }
+    
+    [Authorize(Roles = "Admin")]
+    [HttpPost("{id:int}/{action}")]
+    public async Task<ActionResult> DisOrEnableLandlord(LandlordProfileModel landlord, string action)
+    {
+        var result = await _landlordService.DisOrEnableLandlord(landlord.LandlordId!.Value, action);
+
+        string flashMessageBody, flashMessageType;
+        switch (result)
+        {
+            case ILandlordService.DisableLandlordResult.ErrorLandlordNotFound:
+                flashMessageBody = "Sorry, it appears that no landlord with this ID exists.";
+                flashMessageType = "warning";
+                break;
+            case ILandlordService.DisableLandlordResult.ErrorAlreadyDisabled:
+                flashMessageBody = $"This landlord has already been {action}d.";
+                flashMessageType = "warning";
+                break;
+            case ILandlordService.DisableLandlordResult.Success:
+                flashMessageBody = $"Successfully {action}d landlord.";
+                flashMessageType = "success";
+                break;
+            default:
+                flashMessageBody = "Unknown error occurred.";
+                flashMessageType = "warning";
+                break;
+        }
+
+        _logger.LogInformation(flashMessageBody);
+        AddFlashMessage(flashMessageType, flashMessageBody);
+        return RedirectToAction("Profile", "Landlord", new { Id = landlord.LandlordId.Value });
+    }
 
     [HttpGet]
     [Route("me/properties")]

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -203,22 +203,22 @@ public class LandlordController : AbstractController
     
     [Authorize(Roles = "Admin")]
     [HttpPost("{id:int}/{action}")]
-    public async Task<ActionResult> DisOrEnableLandlord(LandlordProfileModel landlord, string action)
+    public async Task<ActionResult> DisableOrEnableLandlord(LandlordProfileModel landlord, string action)
     {
-        var result = await _landlordService.DisOrEnableLandlord(landlord.LandlordId!.Value, action);
+        var result = await _landlordService.DisableOrEnableLandlord(landlord.LandlordId!.Value, action);
 
         string flashMessageBody, flashMessageType;
         switch (result)
         {
-            case ILandlordService.DisableLandlordResult.ErrorLandlordNotFound:
+            case ILandlordService.DisableOrEnableLandlordResult.ErrorLandlordNotFound:
                 flashMessageBody = "Sorry, it appears that no landlord with this ID exists.";
                 flashMessageType = "warning";
                 break;
-            case ILandlordService.DisableLandlordResult.ErrorAlreadyDisabled:
+            case ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState:
                 flashMessageBody = $"This landlord has already been {action}d.";
                 flashMessageType = "warning";
                 break;
-            case ILandlordService.DisableLandlordResult.Success:
+            case ILandlordService.DisableOrEnableLandlordResult.Success:
                 flashMessageBody = $"Successfully {action}d landlord.";
                 flashMessageType = "success";
                 break;

--- a/web/Database/LandlordDbModel.cs
+++ b/web/Database/LandlordDbModel.cs
@@ -34,6 +34,6 @@ public class LandlordDbModel
     public virtual List<PropertyDbModel> Properties { get; set; } = new();
 
     public string? InviteLink { get; set; } = null; //Nullable & initialised as null as it should be the default value
-
+    public bool Disabled { get; set; }
     public bool IsLandlordForProfit { get; set; }
 }

--- a/web/Enums/ApproveLandlordResult.cs
+++ b/web/Enums/ApproveLandlordResult.cs
@@ -1,0 +1,9 @@
+﻿namespace BricksAndHearts.Enums;
+
+public enum ApproveLandlordResult
+{
+    ErrorLandlordNotFound,
+    ErrorAlreadyApproved,
+    ErrorDuplicateMembershipId,
+    Success
+}

--- a/web/Enums/DisableOrEnableLandlordResult.cs
+++ b/web/Enums/DisableOrEnableLandlordResult.cs
@@ -1,0 +1,8 @@
+﻿namespace BricksAndHearts.Enums;
+
+public enum DisableOrEnableLandlordResult
+{
+    ErrorLandlordNotFound,
+    ErrorAlreadyInState,
+    Success
+}

--- a/web/Enums/LandlordRegistrationResult.cs
+++ b/web/Enums/LandlordRegistrationResult.cs
@@ -1,0 +1,9 @@
+﻿namespace BricksAndHearts.Enums;
+
+public enum LandlordRegistrationResult
+{
+    ErrorLandlordMembershipIdAlreadyRegistered,
+    ErrorLandlordEmailAlreadyRegistered,
+    ErrorUserAlreadyHasLandlordRecord,
+    Success
+}

--- a/web/Enums/LinkUserWithLandlordResult.cs
+++ b/web/Enums/LinkUserWithLandlordResult.cs
@@ -1,0 +1,8 @@
+﻿namespace BricksAndHearts.Enums;
+
+public enum LinkUserWithLandlordResult
+{
+    ErrorLinkDoesNotExist,
+    ErrorUserAlreadyHasLandlordRecord,
+    Success
+}

--- a/web/Migrations/20220822144228_AddDisabledToLandlord.Designer.cs
+++ b/web/Migrations/20220822144228_AddDisabledToLandlord.Designer.cs
@@ -4,6 +4,7 @@ using BricksAndHearts.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
@@ -12,13 +13,14 @@ using NetTopologySuite.Geometries;
 namespace BricksAndHearts.Migrations
 {
     [DbContext(typeof(BricksAndHeartsDbContext))]
-    partial class BricksAndHeartsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220822144228_AddDisabledToLandlord")]
+    partial class AddDisabledToLandlord
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "6.0.8")
+                .HasAnnotation("ProductVersion", "6.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
@@ -139,16 +141,16 @@ namespace BricksAndHearts.Migrations
                     b.Property<bool?>("AcceptsFamily")
                         .HasColumnType("bit");
 
-                    b.Property<bool?>("AcceptsNotInEET")
+                    b.Property<bool?>("AcceptsNotEET")
+                        .HasColumnType("bit");
+
+                    b.Property<bool?>("AcceptsOver35")
                         .HasColumnType("bit");
 
                     b.Property<bool?>("AcceptsPets")
                         .HasColumnType("bit");
 
                     b.Property<bool?>("AcceptsSingleTenant")
-                        .HasColumnType("bit");
-
-                    b.Property<bool?>("AcceptsUnder35")
                         .HasColumnType("bit");
 
                     b.Property<bool?>("AcceptsWithoutGuarantor")
@@ -232,6 +234,9 @@ namespace BricksAndHearts.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
+                    b.Property<bool?>("ETT")
+                        .HasColumnType("bit");
+
                     b.Property<string>("Email")
                         .HasColumnType("nvarchar(max)");
 
@@ -245,7 +250,7 @@ namespace BricksAndHearts.Migrations
                         .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool?>("NotInEET")
+                    b.Property<bool?>("Over35")
                         .HasColumnType("bit");
 
                     b.Property<string>("Phone")
@@ -256,9 +261,6 @@ namespace BricksAndHearts.Migrations
 
                     b.Property<string>("Type")
                         .HasColumnType("nvarchar(max)");
-
-                    b.Property<bool?>("Under35")
-                        .HasColumnType("bit");
 
                     b.Property<bool?>("UniversalCredit")
                         .HasColumnType("bit");

--- a/web/Migrations/20220822144228_AddDisabledToLandlord.cs
+++ b/web/Migrations/20220822144228_AddDisabledToLandlord.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BricksAndHearts.Migrations
+{
+    public partial class AddDisabledToLandlord : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Disabled",
+                table: "Landlord",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Disabled",
+                table: "Landlord");
+        }
+    }
+}

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Data;
 using BricksAndHearts.Auth;
 using BricksAndHearts.Database;
+using BricksAndHearts.Enums;
 using BricksAndHearts.ViewModels;
 using Microsoft.EntityFrameworkCore;
 
@@ -8,36 +9,6 @@ namespace BricksAndHearts.Services;
 
 public interface ILandlordService
 {
-    public enum LandlordRegistrationResult
-    {
-        ErrorLandlordMembershipIdAlreadyRegistered,
-        ErrorLandlordEmailAlreadyRegistered,
-        ErrorUserAlreadyHasLandlordRecord,
-        Success
-    }
-
-    public enum LinkUserWithLandlordResult
-    {
-        ErrorLinkDoesNotExist,
-        ErrorUserAlreadyHasLandlordRecord,
-        Success
-    }
-
-    public enum ApproveLandlordResult
-    {
-        ErrorLandlordNotFound,
-        ErrorAlreadyApproved,
-        ErrorDuplicateMembershipId,
-        Success
-    }
-    
-    public enum DisableOrEnableLandlordResult
-    {
-        ErrorLandlordNotFound,
-        ErrorAlreadyInState,
-        Success
-    }
-
     public Task<(LandlordRegistrationResult result, LandlordDbModel? dbModel)> RegisterLandlord(
         LandlordProfileModel createModel,
         BricksAndHeartsUser user);
@@ -74,7 +45,7 @@ public class LandlordService : ILandlordService
         _dbContext = dbContext;
     }
 
-    public async Task<(ILandlordService.LandlordRegistrationResult result, LandlordDbModel? dbModel)> RegisterLandlord(
+    public async Task<(LandlordRegistrationResult result, LandlordDbModel? dbModel)> RegisterLandlord(
         LandlordProfileModel createModel,
         BricksAndHeartsUser user)
     {
@@ -103,7 +74,7 @@ public class LandlordService : ILandlordService
             // This requires Serializable isolation, otherwise it will not lock any rows, and two racing registrations could create duplicate records
             if (await _dbContext.Landlords.AnyAsync(l => l.Email == createModel.Email))
             {
-                return (ILandlordService.LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered, null);
+                return (LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered, null);
             }
 
             // If the landlord has a membershipId, check there isn't already a Landlord with that membershipId.
@@ -111,7 +82,7 @@ public class LandlordService : ILandlordService
             {
                 if (await _dbContext.Landlords.AnyAsync(l => l.MembershipId == dbModel.MembershipId))
                 {
-                    return (ILandlordService.LandlordRegistrationResult.ErrorLandlordMembershipIdAlreadyRegistered,
+                    return (LandlordRegistrationResult.ErrorLandlordMembershipIdAlreadyRegistered,
                         null);
                 }
             }
@@ -120,7 +91,7 @@ public class LandlordService : ILandlordService
             var userRecord = _dbContext.Users.Single(u => u.Id == user.Id);
             if (userRecord.LandlordId != null)
             {
-                return (ILandlordService.LandlordRegistrationResult.ErrorUserAlreadyHasLandlordRecord, null);
+                return (LandlordRegistrationResult.ErrorUserAlreadyHasLandlordRecord, null);
             }
 
             // Insert the landlord and call SaveChanges
@@ -135,7 +106,7 @@ public class LandlordService : ILandlordService
 
         user.LandlordId = dbModel.Id;
 
-        return (ILandlordService.LandlordRegistrationResult.Success, dbModel);
+        return (LandlordRegistrationResult.Success, dbModel);
     }
 
     public Task<LandlordDbModel?> GetLandlordIfExistsFromId(int? id)
@@ -148,7 +119,7 @@ public class LandlordService : ILandlordService
         return _dbContext.Landlords.Include(l => l.Properties).SingleOrDefaultAsync(l => l.Id == id);
     }
 
-    public async Task<(ILandlordService.LandlordRegistrationResult result, LandlordDbModel? landlord)> RegisterLandlord(
+    public async Task<(LandlordRegistrationResult result, LandlordDbModel? landlord)> RegisterLandlord(
         LandlordProfileModel createModel)
     {
         var dbModel = new LandlordDbModel
@@ -176,7 +147,7 @@ public class LandlordService : ILandlordService
             // This requires Serializable isolation, otherwise it will not lock any rows, and two racing registrations could create duplicate records
             if (await _dbContext.Landlords.AnyAsync(l => l.Email == createModel.Email))
             {
-                return (ILandlordService.LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered, null);
+                return (LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered, null);
             }
 
             // If the landlord has a membershipId, check there isn't already a Landlord with that membershipId.
@@ -184,7 +155,7 @@ public class LandlordService : ILandlordService
             {
                 if (await _dbContext.Landlords.AnyAsync(l => l.MembershipId == dbModel.MembershipId))
                 {
-                    return (ILandlordService.LandlordRegistrationResult.ErrorLandlordMembershipIdAlreadyRegistered,
+                    return (LandlordRegistrationResult.ErrorLandlordMembershipIdAlreadyRegistered,
                         null);
                 }
             }
@@ -196,27 +167,27 @@ public class LandlordService : ILandlordService
             await transaction.CommitAsync();
         }
 
-        return (ILandlordService.LandlordRegistrationResult.Success, dbModel);
+        return (LandlordRegistrationResult.Success, dbModel);
     }
 
-    public async Task<ILandlordService.ApproveLandlordResult> ApproveLandlord(int landlordId, BricksAndHeartsUser user,
+    public async Task<ApproveLandlordResult> ApproveLandlord(int landlordId, BricksAndHeartsUser user,
         string membershipId)
     {
         var landlord = await GetLandlordIfExistsFromId(landlordId);
         if (landlord is null)
         {
-            return ILandlordService.ApproveLandlordResult.ErrorLandlordNotFound;
+            return ApproveLandlordResult.ErrorLandlordNotFound;
         }
 
         if (landlord.CharterApproved)
         {
-            return ILandlordService.ApproveLandlordResult.ErrorAlreadyApproved;
+            return ApproveLandlordResult.ErrorAlreadyApproved;
         }
 
         if (CheckForDuplicateMembershipId(new LandlordProfileModel
                 { LandlordId = landlordId, MembershipId = membershipId }))
         {
-            return ILandlordService.ApproveLandlordResult.ErrorDuplicateMembershipId;
+            return ApproveLandlordResult.ErrorDuplicateMembershipId;
         }
 
         landlord.CharterApproved = true;
@@ -225,7 +196,7 @@ public class LandlordService : ILandlordService
         landlord.MembershipId = membershipId;
 
         await _dbContext.SaveChangesAsync();
-        return ILandlordService.ApproveLandlordResult.Success;
+        return ApproveLandlordResult.Success;
     }
 
     public async Task UnapproveLandlord(int landlordId)
@@ -239,33 +210,29 @@ public class LandlordService : ILandlordService
         await _dbContext.SaveChangesAsync();
     }
 
-    public async Task<ILandlordService.DisableOrEnableLandlordResult> DisableOrEnableLandlord(int landlordId, string action)
+    public async Task<DisableOrEnableLandlordResult> DisableOrEnableLandlord(int landlordId, string action)
     {
         var landlord = await GetLandlordIfExistsFromId(landlordId);
         if (landlord is null)
         {
-            return ILandlordService.DisableOrEnableLandlordResult.ErrorLandlordNotFound;
-        }
-
-        if (action == "disable")
-        {
-            if (landlord.Disabled)
-            {
-                return ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState;
-            }
-            landlord.Disabled = true;
-        }
-        else
-        {
-            if (!landlord.Disabled)
-            {
-                return ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState;
-            }
-            landlord.Disabled = false;
+            return DisableOrEnableLandlordResult.ErrorLandlordNotFound;
         }
         
+        if ((action == "disable" && landlord.Disabled)
+            || (action == "enable" && !landlord.Disabled))
+        {
+            return DisableOrEnableLandlordResult.ErrorAlreadyInState;
+        }
+        
+        landlord.Disabled = action switch
+        {
+            "disable" => true,
+            "enable" => false,
+            _ => landlord.Disabled
+        };
+
         await _dbContext.SaveChangesAsync();
-        return ILandlordService.DisableOrEnableLandlordResult.Success;
+        return DisableOrEnableLandlordResult.Success;
     }
 
     public LandlordDbModel? FindLandlordWithInviteLink(string inviteLink)
@@ -274,7 +241,7 @@ public class LandlordService : ILandlordService
     }
 
 
-    public async Task<ILandlordService.LandlordRegistrationResult> EditLandlordDetails(LandlordProfileModel editModel)
+    public async Task<LandlordRegistrationResult> EditLandlordDetails(LandlordProfileModel editModel)
     {
         var landlordToEdit = await _dbContext.Landlords.SingleAsync(l => l.Id == editModel.LandlordId);
         landlordToEdit.Title = editModel.Title == "Other" ? editModel.TitleInput! : editModel.Title;
@@ -294,7 +261,7 @@ public class LandlordService : ILandlordService
         landlordToEdit.Postcode = editModel.Address.Postcode!;
 
         await _dbContext.SaveChangesAsync();
-        return ILandlordService.LandlordRegistrationResult.Success;
+        return LandlordRegistrationResult.Success;
     }
 
     public bool CheckForDuplicateEmail(LandlordProfileModel editModel)
@@ -317,7 +284,7 @@ public class LandlordService : ILandlordService
     }
 
     // Link existing landlord with user
-    public async Task<ILandlordService.LinkUserWithLandlordResult> LinkExistingLandlordWithUser(
+    public async Task<LinkUserWithLandlordResult> LinkExistingLandlordWithUser(
         string inviteLink,
         BricksAndHeartsUser user)
     {
@@ -330,14 +297,14 @@ public class LandlordService : ILandlordService
             var landlord = _dbContext.Landlords.SingleOrDefault(l => l.InviteLink == inviteLink);
             if (landlord == null)
             {
-                return ILandlordService.LinkUserWithLandlordResult.ErrorLinkDoesNotExist;
+                return LinkUserWithLandlordResult.ErrorLinkDoesNotExist;
             }
 
             // Check the user doesn't already have a landlord associated
             var userRecord = _dbContext.Users.Single(u => u.Id == user.Id);
             if (userRecord.LandlordId != null)
             {
-                return ILandlordService.LinkUserWithLandlordResult.ErrorUserAlreadyHasLandlordRecord;
+                return LinkUserWithLandlordResult.ErrorUserAlreadyHasLandlordRecord;
             }
 
             // Disable invite link
@@ -353,7 +320,7 @@ public class LandlordService : ILandlordService
             user.LandlordId = landlord.Id; // Update the in memory user object
         }
 
-        return ILandlordService.LinkUserWithLandlordResult.Success;
+        return LinkUserWithLandlordResult.Success;
     }
 
     public Task<LandlordDbModel> GetLandlordFromId(int id)

--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -31,10 +31,10 @@ public interface ILandlordService
         Success
     }
     
-    public enum DisableLandlordResult
+    public enum DisableOrEnableLandlordResult
     {
         ErrorLandlordNotFound,
-        ErrorAlreadyDisabled,
+        ErrorAlreadyInState,
         Success
     }
 
@@ -54,7 +54,7 @@ public interface ILandlordService
     public bool CheckForDuplicateMembershipId(LandlordProfileModel editModel);
     public Task<ApproveLandlordResult> ApproveLandlord(int landlordId, BricksAndHeartsUser user, string membershipId);
     public Task UnapproveLandlord(int landlordId);
-    public Task<DisableLandlordResult> DisOrEnableLandlord(int landlordId, string action);
+    public Task<DisableOrEnableLandlordResult> DisableOrEnableLandlord(int landlordId, string action);
     public LandlordDbModel? FindLandlordWithInviteLink(string inviteLink);
     public string? GetLandlordProfilePicture(int landlordId);
 
@@ -239,34 +239,33 @@ public class LandlordService : ILandlordService
         await _dbContext.SaveChangesAsync();
     }
 
-    public async Task<ILandlordService.DisableLandlordResult> DisOrEnableLandlord(int landlordId, string action)
+    public async Task<ILandlordService.DisableOrEnableLandlordResult> DisableOrEnableLandlord(int landlordId, string action)
     {
         var landlord = await GetLandlordIfExistsFromId(landlordId);
         if (landlord is null)
         {
-            return ILandlordService.DisableLandlordResult.ErrorLandlordNotFound;
+            return ILandlordService.DisableOrEnableLandlordResult.ErrorLandlordNotFound;
         }
 
         if (action == "disable")
         {
             if (landlord.Disabled)
             {
-                return ILandlordService.DisableLandlordResult.ErrorAlreadyDisabled;
+                return ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState;
             }
-
             landlord.Disabled = true;
         }
         else
         {
             if (!landlord.Disabled)
             {
-                return ILandlordService.DisableLandlordResult.ErrorAlreadyDisabled;
+                return ILandlordService.DisableOrEnableLandlordResult.ErrorAlreadyInState;
             }
             landlord.Disabled = false;
         }
         
         await _dbContext.SaveChangesAsync();
-        return ILandlordService.DisableLandlordResult.Success;
+        return ILandlordService.DisableOrEnableLandlordResult.Success;
     }
 
     public LandlordDbModel? FindLandlordWithInviteLink(string inviteLink)

--- a/web/ViewModels/LandlordProfileModel.cs
+++ b/web/ViewModels/LandlordProfileModel.cs
@@ -47,6 +47,8 @@ public class LandlordProfileModel
 
     public bool CharterApproved { get; set; }
 
+    public bool Disabled { get; set; }
+    public string Action { get; set; } = "";
     public bool Unassigned { get; set; }
 
     public string? InviteLink { get; set; }
@@ -73,6 +75,7 @@ public class LandlordProfileModel
             LandlordType = landlord.LandlordType,
             MembershipId = landlord.MembershipId,
             CharterApproved = landlord.CharterApproved,
+            Disabled = landlord.Disabled,
             IsLandlordForProfit = landlord.IsLandlordForProfit,
             NumOfProperties = landlord.Properties.Count,
             InviteLink = landlord.InviteLink,

--- a/web/Views/Landlord/Dashboard.cshtml
+++ b/web/Views/Landlord/Dashboard.cshtml
@@ -5,6 +5,24 @@
     ViewData["Title"] = "Dashboard";
 }
 
+@if (Model.CurrentLandlord.Disabled)
+{
+    <div class="row">
+        <div class="col-sm-auto profile-photo-lg">
+            <img src="@(((BricksAndHeartsUser)User.Identity!).GoogleProfileImageUrl ?? Url.Content("~/images/profileDefault.png"))" alt="profile picture">
+        </div>
+        <div class="col">
+            <div class="row">
+                <h6 class="font-body">Hello</h6>
+                <h2 class="font-blue font-h1">@Model.CurrentLandlord.FirstName</h2>
+                <p class="font-body font-orange mt-1">
+                    Your landlord status has been disabled. Please contact Change Ahead for more information.
+                </p>
+            </div>
+        </div>
+    </div>
+    return;
+}
 <div>
     <div class="row">
         <div class="col">

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -150,21 +150,10 @@ else
     {
         <a class="btn btn-primary my-3" type="button" id="copyBtn" onclick="copyLinkToClipboard('@Model.InviteLink');"><i class="bi bi-files"></i> Copy invite link</a>
     }
-    if (Model.Disabled)
+    using (Html.BeginForm("DisableOrEnableLandlord", "Landlord", new { landlordId = Model.LandlordId}, FormMethod.Post))
     {
-        using (Html.BeginForm("DisOrEnableLandlord", "Landlord", new { landlordId = Model.LandlordId }, FormMethod.Post))
-        {
-            <input type="hidden" asp-for="Action" value="enable">
-            <button type="submit" class="btn btn-primary"><i class="bi bi-link"></i>Re-enable landlord</button>
-        }
-    }
-   else
-    {
-        using (Html.BeginForm("DisOrEnableLandlord", "Landlord", new { landlordId = Model.LandlordId}, FormMethod.Post))
-        {
-            <input type="hidden" asp-for="Action" value="disable">
-            <button type="submit" class="btn btn-primary"><i class="bi bi-link"></i>Disable landlord</button>
-        }
+        <input type="hidden" asp-for="Action" value=@(Model.Disabled ? "enable" : "disable")>
+        <button type="submit" class="btn btn-primary"><i class="bi bi-link"></i>@(Model.Disabled ? "Re-enable landlord" : "Disable landlord")</button>
     }
 }
 

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -142,15 +142,32 @@ else
 
 @if (User.IsInRole("Admin"))
 {
-    @using (Html.BeginForm("GetInviteLink", "Admin", new { landlordId = Model.LandlordId }, FormMethod.Post))
+    using (Html.BeginForm("GetInviteLink", "Admin", new { landlordId = Model.LandlordId }, FormMethod.Post))
     {
         <button type="submit" class="btn btn-primary"><i class="bi bi-link"></i> Get invite link</button>
     }
+    if (Model.InviteLink != null)
+    {
+        <a class="btn btn-primary my-3" type="button" id="copyBtn" onclick="copyLinkToClipboard('@Model.InviteLink');"><i class="bi bi-files"></i> Copy invite link</a>
+    }
+    if (Model.Disabled)
+    {
+        using (Html.BeginForm("DisOrEnableLandlord", "Landlord", new { landlordId = Model.LandlordId }, FormMethod.Post))
+        {
+            <input type="hidden" asp-for="Action" value="enable">
+            <button type="submit" class="btn btn-primary"><i class="bi bi-link"></i>Re-enable landlord</button>
+        }
+    }
+   else
+    {
+        using (Html.BeginForm("DisOrEnableLandlord", "Landlord", new { landlordId = Model.LandlordId}, FormMethod.Post))
+        {
+            <input type="hidden" asp-for="Action" value="disable">
+            <button type="submit" class="btn btn-primary"><i class="bi bi-link"></i>Disable landlord</button>
+        }
+    }
 }
-@if (Model.InviteLink != null)
-{
-    <a class="btn btn-primary my-3" type="button" id="copyBtn" onclick="copyLinkToClipboard('@Model.InviteLink');"><i class="bi bi-files"></i> Copy invite link</a>
-}
+
 
 <!-- Modal -->
 <div class="modal fade" id="approveModal" tabindex="-1" aria-labelledby="approveModalLabel" aria-hidden="true">


### PR DESCRIPTION
[DATABASE UPDATES IN THIS BRANCH}
Admins can disable landlords (and then re-enable them) through the landlord's profile.
Disabled landlords will see the following display instead of their dashboard:
![image](https://user-images.githubusercontent.com/108676120/185968946-fbba4500-bf1e-45a3-920c-ea5ce50691b6.png)
Disabled landlords will be blocked from all other landlord pages, and will not see the landlord nav-bar.