### PR TITLE
BNH-195 Add missing back button for edit landlord profile form

### DIFF
--- a/web/Views/Landlord/EditProfilePage.cshtml
+++ b/web/Views/Landlord/EditProfilePage.cshtml
@@ -3,24 +3,26 @@
 @{
     ViewData["Title"] = "Edit Profile";
 }
-<h1>Edit your Landlord Profile</h1>
 
-<hr/>
 <!-- Circles which indicates the steps of the form: -->
-<div class="d-flex justify-content-center">
-    <span class="step"></span>
-    <span class = "stepline"></span>
-    <span class="step"></span>
-    <span class = "stepline"></span>
-    <span class="step"></span>
-    <span class = "stepline"></span>
-    <span class="step"></span>
+<div class="d-flex my-5">
+    <span class="step">1</span>
+    <span class="stepline"></span>
+    <span class="step">2</span>
+    <span class="stepline"></span>
+    <span class="step">3</span>
+    <span class="stepline"></span>
+    <span class="step">4</span>
 </div>
 
-<div class="row">
-    <form method="post" asp-controller="Landlord" asp-action="EditProfileUpdate" id="landlordEntry">
-        <div asp-validation-summary="All" class="text-danger"></div>
-        @Html.HiddenFor(l=>l.LandlordId, new{value = Model.LandlordId})
-        @{ await Html.RenderPartialAsync("_RegisterPagePartial", Model); }
-    </form>
+<div class="mb-4">
+    <a href="#" id="prevBtn" onclick="nextPrev(-1)">&lt; Back</a>
 </div>
+
+<h1 class="font-h1">Edit landlord profile</h1>
+
+<form method="post" asp-controller="Landlord" asp-action="EditProfileUpdate" id="landlordEntry">
+    <div asp-validation-summary="All" class="text-danger"></div>
+    @Html.HiddenFor(l => l.LandlordId, new { value = Model.LandlordId })
+    @{ await Html.RenderPartialAsync("_RegisterPagePartial", Model); }
+</form>

--- a/web/Views/Landlord/Profile.cshtml
+++ b/web/Views/Landlord/Profile.cshtml
@@ -20,7 +20,7 @@
         <div class="mb-4">
             <div class="d-flex">
                 <h3 class="font-h3 d-inline-block">Personal details</h3>
-                <a class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(0);"></a>
+                <a href="#" class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(0);"></a>
             </div>
             <table class="table">
                 <tr>
@@ -37,7 +37,7 @@
         <div class="mb-4">
             <div class="d-flex">
                 <h3 class="font-h3 d-inline-block">Address</h3>
-                <a class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(1);"></a>
+                <a href="#" class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(1);"></a>
             </div>
             <table class="table">
                 <tr>
@@ -70,7 +70,7 @@
         <div class="mb-4">
             <div class="d-flex">
                 <h3 class="font-h3 d-inline-block">Contact</h3>
-                <a class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(1);"></a>
+                <a href="#" class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(1);"></a>
             </div>
             <table class="table">
                 <tr>
@@ -87,7 +87,7 @@
         <div class="mb-4">
             <div class="d-flex">
                 <h3 class="font-h3 d-inline-block">Type</h3>
-                <a class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(2);"></a>
+                <a href="#" class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(2);"></a>
             </div>
             <table class="table">
                 <tr>
@@ -104,7 +104,7 @@
         <div class="mb-4">
             <div class="d-flex">
                 <h3 class="font-h3 d-inline-block">Charter</h3>
-                <a class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(2);"></a>
+                <a href="#" class="bi bi-pencil ms-auto" onclick="location.href='@Url.Action("EditProfilePage", "Landlord", new { landlordId = Model.LandlordId })'; setCurrentTab(2);"></a>
             </div>
             <table class="table">
                 <tr>
@@ -133,11 +133,11 @@
 
 @if (Model.NumOfProperties > 0)
 {
-    <a class="btn btn-primary my-3" href='@Url.Action("ViewProperties", "Landlord", new { id = Model.LandlordId })'>View Properties</a>
+    <a class="btn btn-primary my-3" href='@Url.Action("ViewProperties", "Landlord", new { id = Model.LandlordId })'>View properties</a>
 }
 else
 {
-    <a class="btn btn-primary my-3" href='@Url.Action("PropertyInputStepOnePostcode", "Property", new { landlordId = Model.LandlordId, propertyId = 0, operationType = "add" })'>Add Properties</a>
+    <a class="btn btn-primary my-3" href='@Url.Action("PropertyInputStepOnePostcode", "Property", new { landlordId = Model.LandlordId, propertyId = 0, operationType = "add" })'>Add properties</a>
 }
 
 @if (User.IsInRole("Admin"))

--- a/web/wwwroot/js/registerPageScript.js
+++ b/web/wwwroot/js/registerPageScript.js
@@ -25,8 +25,8 @@ if(localStorage.getItem("storedCurrentTab")!=null){
 showTab(currentTab);
 
 function showTab(currentTab) {
-    document.getElementById("nextBtn").blur()
-    document.getElementById("prevBtn").blur()
+    document.getElementById("nextBtn").blur();
+    document.getElementById("prevBtn").blur();
     let tabList = document.getElementsByClassName("registerTab");
     tabList[currentTab].style.display = "block";
     if (currentTab === 0) {
@@ -40,7 +40,7 @@ function showTab(currentTab) {
     } else {
         document.getElementById("nextBtn").innerHTML = "Next";
     }
-    fixStepIndicator(currentTab)
+    fixStepIndicator(currentTab);
 }
 
 function nextPrev(tabChange) {


### PR DESCRIPTION
The edit landlord form was missing a "back" link (as reported in [BNH-195](https://softwiretech.atlassian.net/browse/BNH-195)). This has been added back in again, as well as a few minor styling improvements.