### PR TITLE
BNH-191 - landlord registration changes

### DIFF
--- a/web/Services/LandlordService.cs
+++ b/web/Services/LandlordService.cs
@@ -145,7 +145,7 @@ public class LandlordService : ILandlordService
     {
         var dbModel = new LandlordDbModel
         {
-            Title = createModel.Title,
+            Title = createModel.Title == "Other" ? createModel.TitleInput! : createModel.Title,
             FirstName = createModel.FirstName,
             LastName = createModel.LastName,
             CompanyName = createModel.CompanyName,
@@ -240,7 +240,7 @@ public class LandlordService : ILandlordService
     public async Task<ILandlordService.LandlordRegistrationResult> EditLandlordDetails(LandlordProfileModel editModel)
     {
         var landlordToEdit = await _dbContext.Landlords.SingleAsync(l => l.Id == editModel.LandlordId);
-        landlordToEdit.Title = editModel.Title;
+        landlordToEdit.Title = editModel.Title == "Other" ? editModel.TitleInput! : editModel.Title;
         landlordToEdit.FirstName = editModel.FirstName;
         landlordToEdit.LastName = editModel.LastName;
         landlordToEdit.CompanyName = editModel.CompanyName;

--- a/web/ViewModels/LandlordProfileModel.cs
+++ b/web/ViewModels/LandlordProfileModel.cs
@@ -14,6 +14,8 @@ public class LandlordProfileModel
     [DisplayName("Title")]
     public string Title { get; set; } = string.Empty;
 
+    public string? TitleInput { get; set; }
+
     [Required]
     [StringLength(255)]
     [DisplayName("First name")]

--- a/web/Views/Admin/PropertyList.cshtml
+++ b/web/Views/Admin/PropertyList.cshtml
@@ -18,8 +18,8 @@
                         new("Sort by rent", "Rent"),
                         new("Sort by location", "Location")
                     },
-                    new { @class = "form-select col h-auto me-3", onchange = "checkIfSelectedValueIsTarget('Location', 'SortBy'); insertDefaultPostcodeIfNotSortByLocation(id)" })
-                <div id="ifTrue" class="col-auto" style="@(Model.SortBy != "Location" ? "display: none;" : "")">
+                    new { @class = "form-select col h-auto me-3", onchange = "displayIfSelectedValueIsTarget('Location', 'SortBy', 'postcode'); insertDefaultPostcodeIfNotSortByLocation(id)" })
+                <div id="postcode" class="col-auto" style="@(Model.SortBy != "Location" ? "display: none;" : "")">
                     <input class="form-control col h-auto me-3" id="target" name="target" required placeholder="Enter postcode to sort by location" pattern="@Constants.PostcodeValidationRegex"/>
                 </div>
                 <button type="submit" class="btn btn-outline-primary col">Sort</button>

--- a/web/Views/Admin/_LandlordTable.cshtml
+++ b/web/Views/Admin/_LandlordTable.cshtml
@@ -50,12 +50,12 @@
                 {
                     GetCharterStatusPill("Pending", "draft", "clock");
                 }
-                <td>
+                <td class="align-middle">
                     <a asp-action="ViewProperties" asp-controller="Landlord" asp-route-id="@landlord.Id" type="button" class="btn btn-primary">
                         Properties
                     </a>
                 </td>
-                <td>
+                <td class="align-middle">
                     <a asp-action="Profile" asp-controller="Landlord" asp-route-id="@landlord.Id" type="button" class="btn btn-primary">
                         Profile
                     </a>

--- a/web/Views/Landlord/_RegisterPagePartial.cshtml
+++ b/web/Views/Landlord/_RegisterPagePartial.cshtml
@@ -16,63 +16,71 @@
 
     <div class="my-3">
         @Html.HiddenFor(m => m.Unassigned, new { value = Model.Unassigned })
-        <label asp-for="Title" class="form-label"></label>
-        <select asp-for="Title" class="form-select" required>
+        <label asp-for="Title" class="form-label">Title*</label>
+        <select asp-for="Title" class="form-select" required
+                id="Title" onchange="displayIfSelectedValueIsTarget('Other', 'Title', 'titleOther')">
             <option selected disabled value="">Title</option>
             <option value="Mr">Mr</option>
             <option value="Mrs">Mrs</option>
             <option value="Miss">Miss</option>
             <option value="Ms">Ms</option>
             <option value="Dr">Dr</option>
+            <option value="Prof">Prof</option>
+            <option value="Other">Other</option>
         </select>
+        <div id="titleOther" class="my-3" style="@(Model.MembershipId == null ? "display: none;" : "")">
+            <label asp-for="TitleInput" class="form-label">Title (other)*</label>
+            <input id="TitleInput" asp-for="TitleInput" class="form-control empty"/>
+            <span asp-validation-for="TitleInput" class="text-danger"></span>
+        </div>
         <span asp-validation-for="Title" class="text-danger"></span>
     </div>
     <div class="my-3">
-        <label asp-for="FirstName" class="form-label"></label>
+        <label asp-for="FirstName" class="form-label">First name*</label>
         <input asp-for="FirstName" class="form-control"/>
         <span asp-validation-for="FirstName" class="text-danger"></span>
     </div>
     <div class="my-3">
-        <label asp-for="LastName" class="form-label"></label>
+        <label asp-for="LastName" class="form-label">Last name*</label>
         <input asp-for="LastName" class="form-control"/>
         <span asp-validation-for="LastName" class="text-danger"></span>
     </div>
 </div>
 
 <div class="registerTab" id="Contact details">
-    <h2 class="font-h3 mb-5">@(!Model.Unassigned ? "Let us get to know you better" : "Tell us a bit about the landlord")</h2>
+    <h2 class="font-h3 mb-5">@(!Model.Unassigned ? "Please provide your personal address" : "Please provide the landlord's personal address")</h2>
 
     <div class="row">
         <div class="col-auto">
             <div class="my-3">
-                <label asp-for="Address.AddressLine1" class="form-label">Address line 1</label>
+                <label asp-for="Address.AddressLine1" class="form-label">Address line 1*</label>
                 <input asp-for="Address.AddressLine1" class="form-control" required/>
                 <span asp-validation-for="Address.AddressLine1" class="text-danger"></span>
             </div>
             <div class="my-3">
-                <label asp-for="Address.AddressLine2" class="form-label">Address line 2 (optional)</label>
+                <label asp-for="Address.AddressLine2" class="form-label">Address line 2</label>
                 <input asp-for="Address.AddressLine2" class="form-control empty"/>
                 <span asp-validation-for="Address.AddressLine2" class="text-danger"></span>
             </div>
             <div class="my-3">
-                <label asp-for="Address.AddressLine3" class="form-label">Address line 3 (optional)</label>
+                <label asp-for="Address.AddressLine3" class="form-label">Address line 3</label>
                 <input asp-for="Address.AddressLine3" class="form-control empty"/>
                 <span asp-validation-for="Address.AddressLine3" class="text-danger"></span>
             </div>
         </div>
         <div class="col-auto">
             <div class="my-3">
-                <label asp-for="Address.TownOrCity" class="form-label">Town or city</label>
+                <label asp-for="Address.TownOrCity" class="form-label">Town or city*</label>
                 <input asp-for="Address.TownOrCity" class="form-control" required/>
                 <span asp-validation-for="Address.TownOrCity" class="text-danger"></span>
             </div>
             <div class="my-3">
-                <label asp-for="Address.County" class="form-label">County</label>
+                <label asp-for="Address.County" class="form-label">County*</label>
                 <input asp-for="Address.County" class="form-control" required/>
                 <span asp-validation-for="Address.County" class="text-danger"></span>
             </div>
             <div class="my-3">
-                <label asp-for="Address.Postcode" class="form-label">Postcode</label>
+                <label asp-for="Address.Postcode" class="form-label">Postcode*</label>
                 <input asp-for="Address.Postcode" class="form-control" required/>
                 <span asp-validation-for="Address.Postcode" class="text-danger"></span>
             </div>
@@ -82,14 +90,14 @@
     <div class="row mt-3">
         <div class="col-auto">
             <div class="my-3">
-                <label asp-for="Email" class="form-label"></label>
+                <label asp-for="Email" class="form-label">Email*</label>
                 <input type="email" asp-for="Email" class="form-control"/>
                 <span asp-validation-for="Email" class="text-danger"></span>
             </div>
         </div>
         <div class="col-auto">
             <div class="my-3">
-                <label asp-for="Phone" class="form-label"></label>
+                <label asp-for="Phone" class="form-label">Phone*</label>
                 <input type="tel" asp-for="Phone" class="form-control"/>
                 <span asp-validation-for="Phone" class="text-danger"></span>
             </div>
@@ -103,7 +111,7 @@
     <div class="row">
         <div class="col-auto">
             <div class="my-3">
-                <label asp-for="LandlordType" class="form-label"></label>
+                <label asp-for="LandlordType" class="form-label">Type of landlord*</label>
                 <select asp-for="LandlordType" class="form-select" required>
                     <option selected disabled value="">Choose a type</option>
                     <option value="Charity">Charity</option>
@@ -123,7 +131,7 @@
                 <span asp-validation-for="IsLandlordForProfit" class="text-danger"></span>
             </div>
             <div class="my-3">
-                <label asp-for="CompanyName" class="form-label">Company name (optional)</label>
+                <label asp-for="CompanyName" class="form-label">Company name</label>
                 <input asp-for="CompanyName" class="form-control empty"/>
                 <span asp-validation-for="CompanyName" class="text-danger"></span>
             </div>
@@ -131,9 +139,9 @@
 
         <div class="col-auto">
             <div class="my-3">
-                <label for="Select" class="form-label">Charter status</label>
+                <label for="Charter" class="form-label">Charter status</label>
                 <select class="form-select" required
-                        id="Select" onchange="checkIfSelectedValueIsTarget('true', 'Select'); clearMembershipIdIfFalse()">
+                        id="Charter" onchange="displayIfSelectedValueIsTarget('true', 'Charter', 'ifTrue', 'ifFalse'); clearMembershipIdIfFalse('true', 'Charter', 'MembershipId')">
                     <!option @(Model.MembershipId != null ? "selected" : "") value="true">Already approved</!option>
                     <!option @(Model.MembershipId == null ? "selected" : "") value="false">Not yet approved</!option>
                 </select>
@@ -143,7 +151,7 @@
                 </div>
             </div>
             <div id="ifTrue" class="my-3" style="@(Model.MembershipId == null ? "display: none;" : "")">
-                <label asp-for="MembershipId" class="form-label">Membership ID</label>
+                <label asp-for="MembershipId" class="form-label">Membership ID*</label>
                 <input asp-for="MembershipId" class="form-control empty"/>
                 <span asp-validation-for="MembershipId" class="text-danger"></span>
             </div>

--- a/web/Views/Property/PropertyInputForm/Availability.cshtml
+++ b/web/Views/Property/PropertyInputForm/Availability.cshtml
@@ -17,7 +17,7 @@
     <div class="col-auto">
         <label asp-for="Availability" class="form-label">Availability</label>
         <select asp-for="Availability" class="form-select" required
-                id="Select" onclick="checkIfSelectedValueIsTarget('@AvailabilityState.AvailableSoon', 'Select'); makeRequiredIfSelectedValueIsTarget('@AvailabilityState.AvailableSoon', 'Select', 'dateInput')">
+                id="Select" onclick="displayIfSelectedValueIsTarget('@AvailabilityState.AvailableSoon', 'Select', 'ifTrue'); makeRequiredIfSelectedValueIsTarget('@AvailabilityState.AvailableSoon', 'Select', 'dateInput')">
             <option selected>@AvailabilityState.Draft</option>
             <option>@AvailabilityState.Available</option>
             <option>@AvailabilityState.AvailableSoon</option>

--- a/web/wwwroot/js/registerPageScript.js
+++ b/web/wwwroot/js/registerPageScript.js
@@ -70,12 +70,14 @@ function validateForm() {
     for (tabInputIterator = 0; tabInputIterator < tabInputList.length; tabInputIterator++) {
         // Validation checks for the form
         let currentField = tabInputList[tabInputIterator]
-        if ((currentField.name === "MembershipId") && ((tabInputList[tabInputIterator-1]).value === "false"))
+        if ((currentField.name === "MembershipId") && ((tabInputList[tabInputIterator-1]).value === "false")
+            || ((currentField.name === "TitleInput") && (tabInputList[tabInputIterator-1]).value !== "Other"))
         {
            currentField.className = "form-control empty";
         }
         if ((currentField.value === "" && currentField.className!=="form-control empty")
             || ((currentField.name === "MembershipId") && (currentField.value === "") && ((tabInputList[tabInputIterator-1]).value === "true"))
+            || ((currentField.name === "TitleInput") && (currentField.value === "") && ((tabInputList[tabInputIterator-1]).value === "Other"))
             || (currentField.type === "email" && (currentField.value.indexOf("@") === -1))
             || (currentField.type === "tel" && !Number.isInteger(Number(currentField.value.replace(/\+/g,"")))))
         {

--- a/web/wwwroot/js/site.js
+++ b/web/wwwroot/js/site.js
@@ -7,13 +7,13 @@ function setValue(elementId, value) {
     document.getElementById(elementId).value = value;
 }
 
-function checkIfSelectedValueIsTarget(target, id) {
+function displayIfSelectedValueIsTarget(target, id, idToShow, idToHide = null) {
     if ($("#" + id + " :selected").val() == target) {
-        $("#ifTrue").show();
-        $("#ifFalse").hide();
+        $("#" + idToShow).show();
+        $("#" + idToHide).hide();
     } else {
-        $("#ifTrue").hide();
-        $("#ifFalse").show();
+        $("#" + idToShow).hide();
+        $("#" + idToHide).show();
     }
 }
 


### PR DESCRIPTION
A few minor changes:
 - asterisks added to show which fields are compulsory (and optional labels therefore removed)
 - text added to Address page to instruct landlords to provide personal address (rather than business or property)
Both those changes visible on this page:
![image](https://user-images.githubusercontent.com/108676120/186179772-b3696ee0-1994-47a6-a354-413e0bd7b765.png)

 - the 'title' dropdown now has an 'Other' option, which brings up a text box in which the user enters their desired title. This is a compulsory field if and only if 'Other' has been selected.
![image](https://user-images.githubusercontent.com/108676120/186180068-3df1978d-dd78-4312-a89b-5f4bd1cb88cc.png)
