### PR TITLE
BNH-193 Make routes more clearly match site navigation

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/HomeControllerTests/HomeControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/HomeControllerTests/HomeControllerTests.cs
@@ -24,7 +24,7 @@ public class HomeControllerTests : HomeControllerTestsBase
         result!.ViewData.Model.Should().BeOfType<HomeViewModel>()
             .Which.IsLoggedIn.Should().Be(false);
     }
-    
+
     [Fact]
     public void Index_WhenCalledByNonAdminNonLandlordUser_ReturnsIndexViewWithRegisterButtons()
     {
@@ -39,7 +39,7 @@ public class HomeControllerTests : HomeControllerTestsBase
         result!.ViewData.Model.Should().BeOfType<HomeViewModel>()
             .Which.IsLoggedIn.Should().Be(true);
     }
-    
+
     [Fact]
     public void Index_WhenCalledByLandlordUser_RedirectsToLandlordDashboard()
     {
@@ -53,9 +53,9 @@ public class HomeControllerTests : HomeControllerTestsBase
         // Assert
         result.Should().BeOfType<RedirectToActionResult>();
         result.Should().NotBeNull();
-        result!.ActionName.Should().BeEquivalentTo("MyDashboard");
+        result!.ActionName.Should().BeEquivalentTo("Dashboard");
     }
-    
+
     [Fact]
     public void Index_WhenCalledByAdminUser_RedirectsToAmindDashboard()
     {

--- a/web/Controllers/AdminController.cs
+++ b/web/Controllers/AdminController.cs
@@ -40,7 +40,7 @@ public class AdminController : AbstractController
         var isAuthenticated = User.Identity?.IsAuthenticated ?? false;
         if (!isAuthenticated)
         {
-            return RedirectToAction("Index", "Home");
+            return RedirectToAction(nameof(HomeController.Index), "Home");
         }
 
         var viewModel =

--- a/web/Controllers/HomeController.cs
+++ b/web/Controllers/HomeController.cs
@@ -22,12 +22,12 @@ public class HomeController : AbstractController
             var user = CurrentUser;
             if (user.IsAdmin)
             {
-                return RedirectToAction("AdminDashboard", "Admin");
+                return RedirectToAction(nameof(AdminController.AdminDashboard), "Admin");
             }
 
             if (user.LandlordId != null)
             {
-                return RedirectToAction("Dashboard", "Landlord");
+                return RedirectToAction(nameof(LandlordController.Dashboard), "Landlord");
             }
         }
 

--- a/web/Controllers/HomeController.cs
+++ b/web/Controllers/HomeController.cs
@@ -27,7 +27,7 @@ public class HomeController : AbstractController
 
             if (user.LandlordId != null)
             {
-                return RedirectToAction("MyDashboard", "Landlord");
+                return RedirectToAction("Dashboard", "Landlord");
             }
         }
 
@@ -39,20 +39,20 @@ public class HomeController : AbstractController
         return View(model);
     }
 
-    [HttpGet]
+    [HttpGet("privacy")]
     public IActionResult Privacy()
     {
         return View();
     }
 
-    [HttpGet]
+    [HttpGet("contact")]
     public IActionResult ContactUs()
     {
         return View(new ContactUsViewModel());
     }
 
     [HttpGet]
-    [Route("/Error/{status:int}")]
+    [Route("/error/{status:int}")]
     public IActionResult Error(int status)
     {
         ErrorService errorService = new ErrorService();

--- a/web/Controllers/LandlordController.cs
+++ b/web/Controllers/LandlordController.cs
@@ -34,7 +34,7 @@ public class LandlordController : AbstractController
         if (currentUser.LandlordId != null && !currentUser.IsAdmin)
         {
             _logger.LogWarning("User {UserId} is already registered, will redirect to profile", currentUser.Id);
-            return Redirect(Url.Action("MyProfile")!);
+            return RedirectToAction(nameof(MyProfile));
         }
 
         if (currentUser.IsAdmin && createUnassigned)
@@ -99,7 +99,7 @@ public class LandlordController : AbstractController
                               + "\n";
                 var subject = "Bricks&Hearts - landlord registration notification";
                 _mailService.TrySendMsgInBackground(msgBody, subject);
-                return RedirectToAction("Profile", "Landlord", new { landlord!.Id });
+                return RedirectToAction(nameof(Profile), "Landlord", new { landlord!.Id });
 
             case ILandlordService.LandlordRegistrationResult.ErrorLandlordEmailAlreadyRegistered:
                 _logger.LogWarning("Email already registered {Email}", createModel.Email);
@@ -114,7 +114,7 @@ public class LandlordController : AbstractController
             case ILandlordService.LandlordRegistrationResult.ErrorUserAlreadyHasLandlordRecord:
                 _logger.LogWarning("User {UserId} already associated with landlord", user.Id);
                 AddFlashMessage("warning", "Already registered");
-                return Redirect(Url.Action("MyProfile")!);
+                return RedirectToAction(nameof(MyProfile));
 
             default:
                 throw new Exception($"Unknown landlord registration error ${result}");
@@ -162,7 +162,7 @@ public class LandlordController : AbstractController
             var message = "Membership ID is required.";
             _logger.LogInformation(message);
             AddFlashMessage("warning", message);
-            return RedirectToAction("Profile", "Landlord", new { Id = landlord.LandlordId!.Value });
+            return RedirectToAction(nameof(Profile), "Landlord", new { Id = landlord.LandlordId!.Value });
         }
 
         var user = CurrentUser;
@@ -196,7 +196,7 @@ public class LandlordController : AbstractController
 
         _logger.LogInformation(flashMessageBody);
         AddFlashMessage(flashMessageType, flashMessageBody);
-        return RedirectToAction("Profile", "Landlord", new { Id = landlord.LandlordId.Value });
+        return RedirectToAction(nameof(Profile), "Landlord", new { Id = landlord.LandlordId.Value });
     }
 
     [HttpGet]
@@ -282,7 +282,7 @@ public class LandlordController : AbstractController
 
         await _landlordService.EditLandlordDetails(editModel);
         _logger.LogInformation("Successfully edited landlord for landlord {LandlordId}", editModel.LandlordId);
-        return RedirectToAction("Profile", new { id = editModel.LandlordId });
+        return RedirectToAction(nameof(Profile), new { id = editModel.LandlordId });
     }
 
     [HttpGet("/invite/{inviteLink}")]
@@ -367,7 +367,7 @@ public class LandlordController : AbstractController
     {
         return fileNames.Select(fileName =>
             {
-                var url = Url.Action("GetImage", new { propertyId, fileName })!;
+                var url = Url.Action(nameof(GetImage), new { propertyId, fileName })!;
                 return new ImageFileUrlModel(fileName, url);
             })
             .ToList();

--- a/web/Controllers/LoginController.cs
+++ b/web/Controllers/LoginController.cs
@@ -8,13 +8,14 @@ namespace BricksAndHearts.Controllers;
 [AllowAnonymous]
 public class LoginController : Controller
 {
+    [HttpGet("/login/google")]
     public IActionResult Google(string returnUrl = "/")
     {
         var properties = new AuthenticationProperties { RedirectUri = returnUrl };
         return Challenge(properties, GoogleDefaults.AuthenticationScheme);
     }
-    
-    [HttpPost]
+
+    [HttpPost("/logout")]
     public async Task<IActionResult> Logout()
     {
         await HttpContext.SignOutAsync();

--- a/web/Controllers/LoginController.cs
+++ b/web/Controllers/LoginController.cs
@@ -19,6 +19,6 @@ public class LoginController : Controller
     public async Task<IActionResult> Logout()
     {
         await HttpContext.SignOutAsync();
-        return RedirectToAction("Index", "Home");
+        return RedirectToAction(nameof(HomeController.Index), "Home");
     }
 }

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -69,10 +69,11 @@ public class PropertyController : AbstractController
             AddFlashMessage("danger", $"Property with Id {propertyId} does not exist");
             if (CurrentUser.LandlordId != null)
             {
-                return RedirectToAction("ViewProperties", "Landlord", new { id = CurrentUser.LandlordId });
+                return RedirectToAction(nameof(LandlordController.ViewProperties), "Landlord",
+                    new { id = CurrentUser.LandlordId });
             }
 
-            return RedirectToAction("Index", "Home");
+            return RedirectToAction(nameof(HomeController.Index), "Home");
         }
 
         if (CurrentUser.IsAdmin == false && CurrentUser.LandlordId != propDb.LandlordId)
@@ -432,7 +433,7 @@ public class PropertyController : AbstractController
     {
         return fileNames.Select(fileName =>
             {
-                var url = Url.Action("GetImage", new { propertyId, fileName })!;
+                var url = Url.Action(nameof(GetImage), new { propertyId, fileName })!;
                 return new ImageFileUrlModel(fileName, url);
             })
             .ToList();

--- a/web/Controllers/TenantController.cs
+++ b/web/Controllers/TenantController.cs
@@ -90,7 +90,7 @@ public class TenantController : AbstractController
     {
         return fileNames.Select(fileName =>
             {
-                var url = Url.Action("GetImage", new { propertyId, fileName })!;
+                var url = Url.Action(nameof(GetImage), new { propertyId, fileName })!;
                 return new ImageFileUrlModel(fileName, url);
             })
             .ToList();
@@ -125,7 +125,7 @@ public class TenantController : AbstractController
         _mailService.TrySendMsgInBackground(propertyLink, tenantEmail, addressToSendTo);
         _logger.LogInformation($"Successfully emailed tenant {tenantEmail}");
         AddFlashMessage("success", $"successfully emailed {tenantEmail}");
-        return RedirectToAction("TenantMatchList", new { currentPropertyId });
+        return RedirectToAction(nameof(TenantMatchList), new { currentPropertyId });
     }
 
     [Authorize(Roles = "Admin")]

--- a/web/Controllers/TenantController.cs
+++ b/web/Controllers/TenantController.cs
@@ -34,7 +34,7 @@ public class TenantController : AbstractController
     }
 
     [Authorize(Roles = "Admin")]
-    [HttpGet]
+    [HttpGet("/admin/lists/tenants")]
     public async Task<IActionResult> TenantList(TenantListModel tenantListModel, string? targetPostcode,
         HousingRequirementModel filter, int page = 1)
     {
@@ -64,7 +64,7 @@ public class TenantController : AbstractController
     }
 
     [Authorize(Roles = "Admin")]
-    [HttpGet("{currentPropertyId:int}/Matches")]
+    [HttpGet("/property/{currentPropertyId:int}/match")]
     public async Task<IActionResult> TenantMatchList(int currentPropertyId)
     {
         var currentProperty =
@@ -77,13 +77,15 @@ public class TenantController : AbstractController
             {
                 Property = currentProperty,
                 Images = GetFilesFromFileNames(fileNames, currentProperty.PropertyId),
-                PropertyTypeCount = _propertyService.CountProperties(currentProperty.LandlordId), 
-                CurrentLandlord = LandlordProfileModel.FromDbModel(await _landlordService.GetLandlordFromId(currentProperty.LandlordId))
+                PropertyTypeCount = _propertyService.CountProperties(currentProperty.LandlordId),
+                CurrentLandlord =
+                    LandlordProfileModel.FromDbModel(
+                        await _landlordService.GetLandlordFromId(currentProperty.LandlordId))
             }
         };
         return View("~/Views/Admin/TenantMatchList.cshtml", tenantMatchListModel);
     }
-    
+
     public List<ImageFileUrlModel> GetFilesFromFileNames(List<string> fileNames, int propertyId)
     {
         return fileNames.Select(fileName =>
@@ -96,7 +98,7 @@ public class TenantController : AbstractController
 
     [Authorize(Roles = "Landlord, Admin")]
     [HttpGet]
-    [Route("{propertyId:int}/{fileName}")]
+    [Route("{propertyId:int}/images/{fileName}")]
     public async Task<IActionResult> GetImage(int propertyId, string fileName)
     {
         if (!_propertyService.IsUserAdminOrCorrectLandlord(CurrentUser, propertyId))
@@ -116,7 +118,7 @@ public class TenantController : AbstractController
     }
 
     [Authorize(Roles = "Admin")]
-    [HttpPost("{currentPropertyId:int}/Matches")]
+    [HttpPost("/property/{currentPropertyId:int}/match")]
     public ActionResult SendMatchLinkEmail(string propertyLink, string tenantEmail, int currentPropertyId)
     {
         var addressToSendTo = new List<string> { tenantEmail };
@@ -127,7 +129,7 @@ public class TenantController : AbstractController
     }
 
     [Authorize(Roles = "Admin")]
-    [HttpPost]
+    [HttpPost("/admin/lists/tenants/import")]
     public async Task<ActionResult> ImportTenants(IFormFile? csvFile)
     {
         if (csvFile == null)
@@ -174,7 +176,7 @@ public class TenantController : AbstractController
     }
 
     [Authorize(Roles = "Admin")]
-    [HttpGet("/sample-tenant-data")]
+    [HttpGet("/admin/lists/tenants/sample-tenant-data")]
     public ActionResult GetSampleTenantCsv()
     {
         return File("~/TenantImportCSV_Template.csv", "text/csv");

--- a/web/Views/Shared/_Layout.cshtml
+++ b/web/Views/Shared/_Layout.cshtml
@@ -27,7 +27,7 @@
 
             <div class="collapse navbar-collapse">
                 <div class="navbar-nav me-auto">
-                    <a class="nav-link text-dark mx-3" asp-controller="Landlord" asp-action="@(User.IsInRole("Landlord") ? "MyDashboard" : "RegisterGet")">List your properties</a>
+                    <a class="nav-link text-dark mx-3" asp-controller="Landlord" asp-action="@(User.IsInRole("Landlord") ? "Dashboard" : "RegisterGet")">List your properties</a>
                     <a class="nav-link text-dark mx-3" asp-controller="Admin" asp-action="AdminDashboard">Facilitate rentals</a>
                 </div>
 
@@ -75,7 +75,7 @@
         @if (User.IsInRole("Landlord"))
         {
             <nav class="navbar navbar-secondary navbar-expand-sm navbar-dark bg-primary py-1">
-                <a asp-controller="Landlord" asp-action="MyDashboard" class="nav-link text-light mx-3">Dashboard</a>
+                <a asp-controller="Landlord" asp-action="Dashboard" class="nav-link text-light mx-3">Dashboard</a>
                 <div class="vr my-2"></div>
                 <a asp-controller="Landlord" asp-action="ViewProperties" class="nav-link text-light mx-3">Properties</a>
             </nav>


### PR DESCRIPTION
- Routes now follow the site navigation
- All admin pages start with `/admin`, all landlord pages start with `/landlord`, and property pages start with `/property`
- The lists pages are of the form `/admin/lists/XX`
- Operations on these pages follow this pattern, e.g. `/admin/lists/tenants/import`
- Individual landlords' dashboards are no longer accessible by admins