### PR TITLE
BNH-176: Ensuring server-side validation and buttons on tenant preference form page function correctly

### DIFF
--- a/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
+++ b/BricksAndHearts.UnitTests/ControllerTests/Property/PropertyControllerTests.cs
@@ -312,20 +312,16 @@ public class PropertyControllerTests : PropertyControllerTestsBase
         UnderTest.ViewData.ModelState.AddModelError("Key", "ErrorMessage");
 
         // Act
-        var result =
-            await UnderTest.PropertyInputStepOnePostcode(formResultModel, 999, operationType,
-                    formResultModel.LandlordId)
-                as
-                RedirectToActionResult;
+        var result = await UnderTest.PropertyInputStepOnePostcode(formResultModel, 999, operationType,
+            formResultModel.LandlordId) as ViewResult;
 
         // Assert
         A.CallTo(() => PropertyService.UpdateProperty(1, A<PropertyViewModel>._, true)).WithAnyArguments()
             .MustNotHaveHappened();
         A.CallTo(() => PropertyService.AddNewProperty(1, A<PropertyViewModel>._, true)).WithAnyArguments()
             .MustNotHaveHappened();
-        result!.ActionName.Should().Be("PropertyInputStepOnePostcode");
-        result.RouteValues.Should().ContainKey("propertyId").WhoseValue.Should().Be(999);
-        result.RouteValues.Should().ContainKey("operationType").WhoseValue.Should().Be(operationType);
+        result!.Model.Should().NotBeNull();
+        result!.Model!.GetType().Should().Be(typeof(PropertyInputModelInitialAddress));
     }
 
     [Theory]

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -177,11 +177,6 @@ public class PropertyController : AbstractController
         if (!ModelState.IsValid)
         {
             return View("PropertyInputForm/InitialAddress", model);
-            return RedirectToAction("PropertyInputStepOnePostcode", "Property",
-                new
-                {
-                    propertyId, operationType, landlordId
-                });
         }
 
         var property = _propertyService.GetPropertyByPropertyId(propertyId);

--- a/web/Controllers/PropertyController.cs
+++ b/web/Controllers/PropertyController.cs
@@ -176,6 +176,7 @@ public class PropertyController : AbstractController
     {
         if (!ModelState.IsValid)
         {
+            return View("PropertyInputForm/InitialAddress", model);
             return RedirectToAction("PropertyInputStepOnePostcode", "Property",
                 new
                 {
@@ -228,10 +229,10 @@ public class PropertyController : AbstractController
         [FromRoute] int propertyId, [FromRoute] string operationType)
     {
         const string nextActionName = "PropertyInputStepThreeDetails";
-        const string currentActionName = "PropertyInputStepTwoAddress";
+        const string currentViewName = "PropertyInputForm/FullAddress";
 
         return await StandardPropertyInputPostMethod(model, propertyId, operationType, nextActionName,
-            currentActionName);
+            currentViewName);
     }
 
     [Authorize(Roles = "Landlord, Admin")]
@@ -254,10 +255,10 @@ public class PropertyController : AbstractController
         [FromRoute] string operationType)
     {
         const string nextActionName = "PropertyInputStepFourDescription";
-        const string currentActionName = "PropertyInputStepThreeDetails";
+        const string currentViewName = "PropertyInputForm/Details";
 
         return await StandardPropertyInputPostMethod(model, propertyId, operationType, nextActionName,
-            currentActionName);
+            currentViewName);
     }
 
     [Authorize(Roles = "Landlord, Admin")]
@@ -279,10 +280,10 @@ public class PropertyController : AbstractController
         [FromRoute] int propertyId, [FromRoute] string operationType)
     {
         const string nextActionName = "PropertyInputStepFiveTenantPreferences";
-        const string currentActionName = "PropertyInputStepFourDescription";
+        const string currentViewName = "PropertyInputForm/Description";
 
         return await StandardPropertyInputPostMethod(model, propertyId, operationType, nextActionName,
-            currentActionName);
+            currentViewName);
     }
 
     [Authorize(Roles = "Landlord, Admin")]
@@ -306,10 +307,10 @@ public class PropertyController : AbstractController
         [FromRoute] int propertyId, [FromRoute] string operationType)
     {
         const string nextActionName = "PropertyInputStepSixAvailability";
-        const string currentActionName = "PropertyInputStepFiveTenantPreferences";
+        const string currentViewName = "PropertyInputForm/TenantPreferences";
 
         return await StandardPropertyInputPostMethod(model, propertyId, operationType, nextActionName,
-            currentActionName);
+            currentViewName);
     }
 
     [Authorize(Roles = "Landlord, Admin")]
@@ -332,12 +333,7 @@ public class PropertyController : AbstractController
     {
         if (!ModelState.IsValid)
         {
-            return RedirectToAction("PropertyInputStepSixAvailability", "Property",
-                new
-                {
-                    propertyId,
-                    operationType
-                });
+            return View("PropertyInputForm/Availability", model);
         }
 
         if (!_propertyService.IsUserAdminOrCorrectLandlord(CurrentUser, propertyId))
@@ -380,16 +376,11 @@ public class PropertyController : AbstractController
     }
 
     private async Task<ActionResult> StandardPropertyInputPostMethod(PropertyInputModelBase model, int propertyId,
-        string operationType, string nextActionName, string currentActionName)
+        string operationType, string nextActionName, string currentViewName)
     {
         if (!ModelState.IsValid)
         {
-            return RedirectToAction(currentActionName, "Property",
-                new
-                {
-                    propertyId,
-                    operationType
-                });
+            return View(currentViewName, model);
         }
 
         if (!_propertyService.IsUserAdminOrCorrectLandlord(CurrentUser, propertyId))

--- a/web/ViewModels/PropertyInput/PropertyInputModelTenantPreferences.cs
+++ b/web/ViewModels/PropertyInput/PropertyInputModelTenantPreferences.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using BricksAndHearts.Database;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
 
@@ -7,13 +7,13 @@ namespace BricksAndHearts.ViewModels.PropertyInput;
 public class PropertyInputModelTenantPreferences : PropertyInputModelBase, IValidatableObject
 {
     [Required]
-    public bool? AcceptsSingleTenant { get; set; }
+    public bool AcceptsSingleTenant { get; set; }
 
     [Required]
-    public bool? AcceptsCouple { get; set; }
+    public bool AcceptsCouple { get; set; }
 
     [Required]
-    public bool? AcceptsFamily { get; set; }
+    public bool AcceptsFamily { get; set; }
 
     [Required]
     public bool? AcceptsPets { get; set; }
@@ -49,9 +49,9 @@ public class PropertyInputModelTenantPreferences : PropertyInputModelBase, IVali
         base.InitialiseViewModel(property);
         Step = 5;
         Title = "What kind of tenant would you prefer?";
-        AcceptsSingleTenant = property.AcceptsSingleTenant;
-        AcceptsCouple = property.AcceptsCouple;
-        AcceptsFamily = property.AcceptsFamily;
+        AcceptsSingleTenant = property.AcceptsSingleTenant ?? false;
+        AcceptsCouple = property.AcceptsCouple ?? false;
+        AcceptsFamily = property.AcceptsFamily ?? false;
         AcceptsPets = property.AcceptsPets;
         AcceptsBenefits = property.AcceptsBenefits;
         AcceptsNotInEET = property.AcceptsNotInEET;

--- a/web/ViewModels/PropertyInput/PropertyInputModelTenantPreferences.cs
+++ b/web/ViewModels/PropertyInput/PropertyInputModelTenantPreferences.cs
@@ -19,19 +19,19 @@ public class PropertyInputModelTenantPreferences : PropertyInputModelBase, IVali
     public bool? AcceptsPets { get; set; }
 
     [Required]
-    public bool? AcceptsNotInEET { get; set; }
+    public bool AcceptsNotInEET { get; set; }
 
     [Required]
-    public bool? AcceptsCredit { get; set; }
+    public bool AcceptsCredit { get; set; }
 
     [Required]
-    public bool? AcceptsBenefits { get; set; }
+    public bool AcceptsBenefits { get; set; }
 
     [Required]
-    public bool? AcceptsUnder35 { get; set; }
+    public bool AcceptsUnder35 { get; set; }
 
     [Required]
-    public bool? AcceptsWithoutGuarantor { get; set; }
+    public bool AcceptsWithoutGuarantor { get; set; }
 
     [ValidateNever]
     public override string PreviousAction { get; set; } = "PropertyInputStepFourDescription";
@@ -53,11 +53,11 @@ public class PropertyInputModelTenantPreferences : PropertyInputModelBase, IVali
         AcceptsCouple = property.AcceptsCouple ?? false;
         AcceptsFamily = property.AcceptsFamily ?? false;
         AcceptsPets = property.AcceptsPets;
-        AcceptsBenefits = property.AcceptsBenefits;
-        AcceptsNotInEET = property.AcceptsNotInEET;
-        AcceptsWithoutGuarantor = property.AcceptsWithoutGuarantor;
-        AcceptsCredit = property.AcceptsCredit;
-        AcceptsUnder35 = property.AcceptsUnder35;
+        AcceptsBenefits = property.AcceptsBenefits ?? false;
+        AcceptsNotInEET = property.AcceptsNotInEET ?? false;
+        AcceptsWithoutGuarantor = property.AcceptsWithoutGuarantor ?? false;
+        AcceptsCredit = property.AcceptsCredit ?? false;
+        AcceptsUnder35 = property.AcceptsUnder35 ?? false;
     }
 
     public override PropertyViewModel FormToViewModel()

--- a/web/Views/Property/PropertyInputForm/TenantPreferences.cshtml
+++ b/web/Views/Property/PropertyInputForm/TenantPreferences.cshtml
@@ -7,15 +7,15 @@
 
     <div class="row g-3">
         <div class="col-auto d-grid">
-            @Html.CheckBox("AcceptsSingleTenant", Model.AcceptsSingleTenant ?? false, new { @class = "btn-check" })
+            <input type="checkbox" asp-for="AcceptsSingleTenant" value="@(Model.AcceptsSingleTenant.ToString())" class="check-min-one" onchange="ifNoneCheckedAddRequiredIfAnyCheckedRemoveRequired()"/>
             <label asp-for="AcceptsSingleTenant" class="btn btn-outline-blue shadow-none pill-check">Single tenant</label>
         </div>
         <div class="col-auto d-grid">
-            @Html.CheckBox("AcceptsCouple", Model.AcceptsCouple ?? false, new { @class = "btn-check" })
+            <input type="checkbox" asp-for="AcceptsCouple" value="@(Model.AcceptsCouple.ToString())" class="check-min-one" onchange="ifNoneCheckedAddRequiredIfAnyCheckedRemoveRequired()"/>
             <label asp-for="AcceptsCouple" class="btn btn-outline-blue shadow-none pill-check">Couple</label>
         </div>
         <div class="col-auto d-grid">
-            @Html.CheckBox("AcceptsFamily", Model.AcceptsFamily ?? false, new { @class = "btn-check" })
+            <input type="checkbox" asp-for="AcceptsFamily" value="@(Model.AcceptsFamily.ToString())" class="check-min-one" onchange="ifNoneCheckedAddRequiredIfAnyCheckedRemoveRequired()"/>
             <label asp-for="AcceptsFamily" class="btn btn-outline-blue shadow-none pill-check">Family (3+)</label>
         </div>
     </div>

--- a/web/Views/Property/PropertyInputForm/TenantPreferences.cshtml
+++ b/web/Views/Property/PropertyInputForm/TenantPreferences.cshtml
@@ -7,15 +7,15 @@
 
     <div class="row g-3">
         <div class="col-auto d-grid">
-            <input type="checkbox" asp-for="AcceptsSingleTenant" value="@(Model.AcceptsSingleTenant.ToString())" class="check-min-one" onchange="ifNoneCheckedAddRequiredIfAnyCheckedRemoveRequired()"/>
+            <input type="checkbox" asp-for="AcceptsSingleTenant" class="btn-check"/>
             <label asp-for="AcceptsSingleTenant" class="btn btn-outline-blue shadow-none pill-check">Single tenant</label>
         </div>
         <div class="col-auto d-grid">
-            <input type="checkbox" asp-for="AcceptsCouple" value="@(Model.AcceptsCouple.ToString())" class="check-min-one" onchange="ifNoneCheckedAddRequiredIfAnyCheckedRemoveRequired()"/>
+            <input type="checkbox" asp-for="AcceptsCouple" class="btn-check"/>
             <label asp-for="AcceptsCouple" class="btn btn-outline-blue shadow-none pill-check">Couple</label>
         </div>
         <div class="col-auto d-grid">
-            <input type="checkbox" asp-for="AcceptsFamily" value="@(Model.AcceptsFamily.ToString())" class="check-min-one" onchange="ifNoneCheckedAddRequiredIfAnyCheckedRemoveRequired()"/>
+            <input type="checkbox" asp-for="AcceptsFamily" class="btn-check"/>
             <label asp-for="AcceptsFamily" class="btn btn-outline-blue shadow-none pill-check">Family (3+)</label>
         </div>
     </div>
@@ -37,31 +37,31 @@
 <div class="my-4 py-3">
     <label class="form-label">Will you accept tenants:</label>
     <div class="form-check">
-        @Html.CheckBox("AcceptsCredit", Model.AcceptsCredit ?? false, new { @class = "form-check-input" })
+        <input type="checkbox" asp-for="AcceptsCredit" class="form-check-input"/>
         <label asp-for="AcceptsCredit" class="form-check-label">
             on Universal Credit
         </label>
     </div>
     <div class="form-check">
-        @Html.CheckBox("AcceptsBenefits", Model.AcceptsBenefits ?? false, new { @class = "form-check-input" })
+        <input type="checkbox" asp-for="AcceptsBenefits" class="form-check-input"/>
         <label asp-for="AcceptsBenefits" class="form-check-label">
             on Universal Credit or housing benefits?
         </label>
     </div>
     <div class="form-check">
-        @Html.CheckBox("AcceptsNotEET", Model.AcceptsNotInEET ?? false, new { @class = "form-check-input" })
+        <input type="checkbox" asp-for="AcceptsNotInEET" class="form-check-input"/>
         <label asp-for="AcceptsNotInEET" class="form-check-label">
             not in EET (Employment, Education, or Training)?
         </label>
     </div>
     <div class="form-check">
-        @Html.CheckBox("AcceptsWithoutGuarantor", Model.AcceptsWithoutGuarantor ?? false, new { @class = "form-check-input" })
+        <input type="checkbox" asp-for="AcceptsWithoutGuarantor" class="form-check-input"/>
         <label asp-for="AcceptsWithoutGuarantor" class="form-check-label">
             without a rent guarantor?
         </label>
     </div>
     <div class="form-check">
-        @Html.CheckBox("AcceptsOver35", Model.AcceptsUnder35 ?? false, new { @class = "form-check-input" })
+        <input type="checkbox" asp-for="AcceptsUnder35" class="form-check-input"/>
         <label asp-for="AcceptsUnder35" class="form-check-label">
             that are under 35?
         </label>

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -98,7 +98,7 @@ body {
     background: white;
 }
 
-.btn-outline-blue:hover, .btn-outline-blue:focus, .btn-outline-blue:active, .btn-outline-blue:active:focus, .btn-check:checked + .btn-outline-blue, .btn-check:active + .btn-outline-blue, .btn-outline-blue.active, .btn-outline-blue.dropdown-toggle.show {
+.btn-outline-blue:hover, .btn-outline-blue:focus, .btn-outline-blue:active, .btn-outline-blue:active:focus, .btn-check:checked ~ .btn-outline-blue, .pill-check:active, .btn-check:active + .btn-outline-blue, .btn-outline-blue.active, .btn-outline-blue.dropdown-toggle.show {
     background-color: var(--blue);
     border-color: var(--blue);
     color: var(--white);
@@ -114,7 +114,7 @@ body {
     border-color: grey;
 }
 
-.statbox-icon{
+.statbox-icon {
     color: var(--blue);
     background-color: var(--paleBlue);
     border-radius: 20px;
@@ -122,25 +122,25 @@ body {
     text-align: center;
 }
 
-.card-stat{
+.card-stat {
     width: 90%;
     height: 100%;
     background-color: var(--white);
 }
 
-.card-home{
+.card-home {
     width: 80%;
     height: 100%;
     background-color: var(--blue);
 }
 
-.bi-register{
+.bi-register {
     font-size: 85px;
     background-color: var(--blue);
     color: var(--white)
 }
 
-.card-text-home{
+.card-text-home {
     width: 100%;
     height: 40%;
     background-color: var(--white)
@@ -321,7 +321,7 @@ input:checked + .pill-check i {
     text-decoration: none;
 }
 
-.icon-contact{
+.icon-contact {
     font-size: 32px;
 }
 

--- a/web/wwwroot/js/site.js
+++ b/web/wwwroot/js/site.js
@@ -17,6 +17,25 @@ function displayIfSelectedValueIsTarget(target, id, idToShow, idToHide = null) {
     }
 }
 
+function ifNoneCheckedAddRequiredIfAnyCheckedRemoveRequired() {
+    let checkboxes = document.getElementsByClassName('check-min-one');
+    let checked = false;
+    checkboxes.forEach(box => {
+        if (box.checked === true) {
+            checked = true;
+        }
+    })
+    if (checked) {
+        checkboxes.forEach(box => {
+            box.removeAttr('required')
+        })
+    } else {
+        checkboxes.forEach(box => {
+            box.prop('required', true)
+        })
+    }
+}
+
 function makeRequiredIfSelectedValueIsTarget(target, id, idToRequire) {
     if ($("#" + id + " :selected").val() == target) {
         $("#" + idToRequire).prop('required', true);
@@ -24,6 +43,15 @@ function makeRequiredIfSelectedValueIsTarget(target, id, idToRequire) {
         $("#" + idToRequire).removeAttr('required');
     }
 }
+
+function makeRequiredIfNoneAreSelected(target, id, idToRequire) {
+    if ($("#" + id + " :selected").val() == target) {
+        $("#" + idToRequire).prop('required', true);
+    } else {
+        $("#" + idToRequire).removeAttr('required');
+    }
+}
+
 
 function insertDefaultPostcodeIfNotSortByLocation(id) {
     if ($("#" + id + " :selected").val() == "Location") {

--- a/web/wwwroot/js/site.js
+++ b/web/wwwroot/js/site.js
@@ -17,25 +17,6 @@ function displayIfSelectedValueIsTarget(target, id, idToShow, idToHide = null) {
     }
 }
 
-function ifNoneCheckedAddRequiredIfAnyCheckedRemoveRequired() {
-    let checkboxes = document.getElementsByClassName('check-min-one');
-    let checked = false;
-    checkboxes.forEach(box => {
-        if (box.checked === true) {
-            checked = true;
-        }
-    })
-    if (checked) {
-        checkboxes.forEach(box => {
-            box.removeAttr('required')
-        })
-    } else {
-        checkboxes.forEach(box => {
-            box.prop('required', true)
-        })
-    }
-}
-
 function makeRequiredIfSelectedValueIsTarget(target, id, idToRequire) {
     if ($("#" + id + " :selected").val() == target) {
         $("#" + idToRequire).prop('required', true);
@@ -43,15 +24,6 @@ function makeRequiredIfSelectedValueIsTarget(target, id, idToRequire) {
         $("#" + idToRequire).removeAttr('required');
     }
 }
-
-function makeRequiredIfNoneAreSelected(target, id, idToRequire) {
-    if ($("#" + id + " :selected").val() == target) {
-        $("#" + idToRequire).prop('required', true);
-    } else {
-        $("#" + idToRequire).removeAttr('required');
-    }
-}
-
 
 function insertDefaultPostcodeIfNotSortByLocation(id) {
     if ($("#" + id + " :selected").val() == "Location") {


### PR DESCRIPTION
-Users can no longer submit their preferences without selecting at least one of Single, Couple, Family
![image](https://user-images.githubusercontent.com/36637730/186215935-f3ff4e20-3dd9-47b7-bb4c-fb8b6383fe14.png)


-Users no longer have their form page reset to blank if the model is invalid 
-The Single, Couple, Family buttons now style correctly, appearing filled in with colour if the underlying value is true.
![image](https://user-images.githubusercontent.com/36637730/186216087-431b771c-98a9-423d-9668-dbdc5ecc9717.png)

