### PR TITLE
Bnh 194 navbar restyling for mobiles

### DIFF
--- a/web/Views/Shared/_Layout.cshtml
+++ b/web/Views/Shared/_Layout.cshtml
@@ -34,18 +34,20 @@
                 <div class="navbar-nav">
                     @if (User.Identity?.IsAuthenticated == true)
                     {
-                        @if (User.IsInRole("Landlord"))
-                        {
-                            <div class="d-flex align-items-center mx-3 me-sm-0 py-2 py-sm-0">
-                                <a asp-controller="Landlord" asp-action="Profile" asp-route-id="@(((BricksAndHeartsUser)User.Identity).LandlordId!.Value)" class="profile-photo-sm">
-                                    <img src="@(((BricksAndHeartsUser)User.Identity).GoogleProfileImageUrl ?? Url.Content("~/images/profileDefault.png"))" alt="Profile picture" referrerpolicy="no-referrer"/>
-                                </a>
-                            </div>
-                        }
-                        @using (Html.BeginForm("Logout", "Login", FormMethod.Post))
-                        {
-                            <button type="submit" class="btn btn-thin btn-outline-primary mx-3">Log out</button>
-                        }
+                        <div class="d-flex">
+                            @if (User.IsInRole("Landlord"))
+                            {
+                                <div class="d-flex align-items-center me-0 py-0 flex-grow-1">
+                                    <a asp-controller="Landlord" asp-action="Profile" asp-route-id="@(((BricksAndHeartsUser)User.Identity).LandlordId!.Value)" class="profile-photo-sm">
+                                        <img src="@(((BricksAndHeartsUser)User.Identity).GoogleProfileImageUrl ?? Url.Content("~/images/profileDefault.png"))" alt="Profile picture" referrerpolicy="no-referrer"/>
+                                    </a>
+                                </div>
+                            }
+                            @using (Html.BeginForm("Logout", "Login", FormMethod.Post))
+                            {
+                                <button type="submit" class="btn btn-thin btn-outline-primary mx-3 justify-content-end">Log out</button>
+                            }
+                        </div>
                     }
                     else
                     {

--- a/web/Views/Shared/_Layout.cshtml
+++ b/web/Views/Shared/_Layout.cshtml
@@ -16,7 +16,7 @@
 
 <body class="d-flex flex-column h-100">
 <header>
-    <nav class="navbar navbar-primary navbar-expand-sm navbar-light border-bottom bg-white box-shadow">
+    <nav class="navbar navbar-primary navbar-expand-md navbar-light border-bottom bg-white box-shadow">
         <div class="container-fluid">
             <a class="navbar-brand fw-bold ms-4 me-5" asp-controller="Home" asp-action="Index">Bricks & Hearts</a>
 
@@ -60,24 +60,42 @@
     {
         @if (User.IsInRole("Admin"))
         {
-            <nav class="navbar navbar-secondary navbar-expand-sm navbar-dark bg-primary py-1">
-                <a asp-controller="Admin" asp-action="AdminDashboard" class="nav-link text-light mx-3">Dashboard</a>
-                <div class="vr my-2"></div>
-                <a asp-controller="Admin" asp-action="GetAdminList" class="nav-link text-light mx-3">Admin list</a>
-                <div class="vr my-2"></div>
-                <a asp-controller="Admin" asp-action="LandlordList" class="nav-link text-light mx-3">Landlord list</a>
-                <div class="vr my-2"></div>
-                <a asp-controller="Tenant" asp-action="TenantList" class="nav-link text-light mx-3">Tenant list</a>
-                <div class="vr my-2"></div>
-                <a asp-controller="Property" asp-action="PropertyList" class="nav-link text-light mx-3">Property list</a>
+            <nav class="navbar navbar-secondary navbar-expand-md navbar-dark bg-primary py-1">
+                <div class="collapse navbar-collapse">
+                    <div class="d-flex justify-content-start nav-sub col-auto">
+                        <a asp-controller="Admin" asp-action="AdminDashboard" class="nav-link text-light mx-3">Dashboard</a>
+                    </div>
+                    <div class="vr my-2 hidden-vr"></div>
+                    <div class="d-flex justify-content-start nav-sub col-auto">
+                        <a asp-controller="Admin" asp-action="GetAdminList" class="nav-link text-light mx-3">Admin list</a>
+                    </div>
+                    <div class="vr my-2 hidden-vr"></div>
+                    <div class="d-flex justify-content-start nav-sub col-auto">
+                        <a asp-controller="Admin" asp-action="LandlordList" class="nav-link text-light mx-3">Landlord list</a>
+                    </div>
+                    <div class="vr my-2 hidden-vr"></div>
+                    <div class="d-flex justify-content-start nav-sub col-auto">
+                        <a asp-controller="Tenant" asp-action="TenantList" class="nav-link text-light mx-3">Tenant list</a>
+                    </div>
+                    <div class="vr my-2 hidden-vr"></div>
+                    <div class="d-flex justify-content-start col-auto">
+                        <a asp-controller="Property" asp-action="PropertyList" class="nav-link text-light mx-3">Property list</a>
+                    </div>
+                </div>
             </nav>
         }
         @if (User.IsInRole("Landlord"))
         {
-            <nav class="navbar navbar-secondary navbar-expand-sm navbar-dark bg-primary py-1">
-                <a asp-controller="Landlord" asp-action="Dashboard" class="nav-link text-light mx-3">Dashboard</a>
-                <div class="vr my-2"></div>
-                <a asp-controller="Landlord" asp-action="ViewProperties" class="nav-link text-light mx-3">Properties</a>
+            <nav class="navbar navbar-secondary navbar-expand-md navbar-dark bg-primary py-1">
+                <div class="collapse navbar-collapse">
+                    <div class="d-flex justify-content-start nav-sub col-auto">
+                        <a asp-controller="Landlord" asp-action="Dashboard" class="nav-link text-light mx-3">Dashboard</a>
+                    </div>
+                    <div class="vr my-2 hidden-vr"></div>
+                    <div class="d-flex justify-content-start col-auto">
+                        <a asp-controller="Landlord" asp-action="ViewProperties" class="nav-link text-light mx-3">Properties</a>
+                    </div>
+                </div>
             </nav>
         }
     }

--- a/web/wwwroot/css/site.css
+++ b/web/wwwroot/css/site.css
@@ -39,6 +39,22 @@ body {
     padding-right: 3%;
 }
 
+.nav-sub {
+    border-bottom: 0;
+}
+.hidden-vr {
+    display: inline;
+}
+
+@media screen and (max-width: 768px) {
+    .nav-sub {
+        border-bottom: 2px solid rgba(236, 242, 255, 0.3);
+    }
+    .hidden-vr {
+        display: none;
+    }
+}
+
 .profileBox {
     width: 280px;
 }


### PR DESCRIPTION
navbar looks the same on desktop
![image](https://user-images.githubusercontent.com/43523985/186404152-5b8a37a1-9133-4244-9fc4-d6e2deceece2.png)

unexpanded on mobile

![image](https://user-images.githubusercontent.com/43523985/186404259-6f9f2a5d-d82c-4f53-9595-15d42760399d.png)

expanded on mobile

![image](https://user-images.githubusercontent.com/43523985/186404335-164f0ce3-fab1-4584-a8a8-081060f28bc9.png)

(double navbars in this image, imagine only 1 blue navbar is present if a user is not both a landlord and admin)